### PR TITLE
fix: Replace fragile reflection-based platform dependency unwrapping with type check

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -19,7 +19,7 @@ Issues identified during code review. Severity: **high**, **medium**, **low**.
 ### 3. Fragile reflection-based dependency unwrapping in `ProjectMetadataFactory`
 - **File**: `src/main/kotlin/.../ProjectMetadataFactory.kt` (lines 130–140)
 - **Issue**: Platform/BOM dependencies are detected via reflection (`getDependency` method lookup). This relies on undocumented Gradle internals, has no null check on the result, and silently fails — meaning BOM-dependent projects may not be detected correctly.
-- **Status**: Open
+- **Status**: Fixed in `fix-reflection-dependency-unwrapping` — reflection removed; `platform(project(...))` returns the same `ProjectDependency` with platform attributes set, so it is already caught by the `is ProjectDependency` check. Unit test added to prevent regression.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the reflection-based `else` branch in `ProjectMetadataFactory.findProjectDependencies()` that called `getDependency()` via reflection on undocumented Gradle internals
- Gradle's `platform(project(":X"))` returns the same `ProjectDependency` object with `endorseStrictVersions()` called and the `Category.REGULAR_PLATFORM` attribute set — it does not wrap the dependency in a different type
- The existing `is ProjectDependency` check already covers platform project dependencies, making the reflection code dead code
- Adds a unit test to `ProjectMetadataFactoryTest` to confirm platform project dependencies are detected correctly without reflection

Fixes issue #3 from CODE_REVIEW.md.

## Test plan

- [ ] Run `./gradlew check` to verify all existing tests pass
- [ ] Verify new unit test `should detect platform project dependency without reflection` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)