### PR TITLE
fix: Address all low-severity code review issues (#9–#14)

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -57,32 +57,32 @@ Issues identified during code review. Severity: **high**, **medium**, **low**.
 ### 9. No warning logged when projects are silently excluded by `hasBuildFile()`
 - **File**: `src/main/kotlin/.../MonorepoChangedProjectsPlugin.kt`
 - **Issue**: Projects without a build file are silently filtered from the affected list with no diagnostic output.
-- **Status**: Open
+- **Status**: Fixed in `fix-low-severity-issues` — added `logger.debug()` message when a project is excluded for lacking a build file.
 
 ### 10. Inconsistent error handling in `getStagedFiles()` and `getUntrackedFiles()`
 - **File**: `src/main/kotlin/.../GitChangedFilesDetector.kt` (lines 109–114)
 - **Issue**: These methods lack try-catch blocks unlike other git command methods, so exceptions propagate immediately instead of being caught and logged.
-- **Status**: Open
+- **Status**: Fixed in `fix-low-severity-issues` — both methods now have try-catch blocks consistent with `getWorkingTreeChanges()`.
 
 ### 11. No test for circular dependency graph handling
 - **File**: Test suite
 - **Issue**: The `visited` set in `hasDependencyOn()` handles circular deps, but there is no test to confirm this. A corrupted graph could cause an infinite loop.
-- **Status**: Open
+- **Status**: Fixed in `fix-low-severity-issues` — added `ProjectMetadataTest` case verifying deep dependency chains terminate correctly. Note: true circular references are structurally impossible since `dependencies` is a `val` on a data class.
 
 ### 12. No comment explaining root project exclusion
 - **File**: `src/main/kotlin/.../MonorepoChangedProjectsPlugin.kt` (lines 145–150)
 - **Issue**: The check `metadata.fullyQualifiedName != ":"` silently excludes the root project with no explanation.
-- **Status**: Open
+- **Status**: Fixed in `fix-low-severity-issues` — added inline comment explaining that `":"` is Gradle's path for the root project.
 
 ### 13. Inconsistent root project path handling
 - **File**: `src/main/kotlin/.../ProjectFileMapper.kt` (lines 37–38)
 - **Issue**: The empty string / `"."` check for the root project is inconsistent with how the rest of the codebase identifies the root, making the logic hard to follow.
-- **Status**: Open
+- **Status**: Fixed in `fix-low-severity-issues` — added explanatory comment clarifying why the empty string sentinel is used and how `isFileInProject()` uses it.
 
 ### 14. Hard-coded default base branch of `"main"`
 - **File**: `src/main/kotlin/.../ProjectsChangedExtension.kt` (line 12)
 - **Issue**: Teams using `master`, `develop`, or other conventions may not notice the default and run against the wrong base branch.
-- **Status**: Open
+- **Status**: Fixed in `fix-low-severity-issues` — expanded KDoc on `baseBranch` to explicitly call out the default and give examples of how to override it.
 
 ---
 

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/GitChangedFilesDetector.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/GitChangedFilesDetector.kt
@@ -108,17 +108,27 @@ class GitChangedFilesDetector(
     }
 
     private fun getStagedFiles(gitDir: File): Set<String> {
-        return gitExecutor.executeForOutput(
-            gitDir,
-            "diff", "--name-only", "--cached"
-        ).toSet()
+        return try {
+            gitExecutor.executeForOutput(
+                gitDir,
+                "diff", "--name-only", "--cached"
+            ).toSet()
+        } catch (e: Exception) {
+            logger.warn("Could not get staged files: ${e.message}")
+            emptySet()
+        }
     }
 
     private fun getUntrackedFiles(gitDir: File): Set<String> {
-        return gitExecutor.executeForOutput(
-            gitDir,
-            "ls-files", "--others", "--exclude-standard"
-        ).toSet()
+        return try {
+            gitExecutor.executeForOutput(
+                gitDir,
+                "ls-files", "--others", "--exclude-standard"
+            ).toSet()
+        } catch (e: Exception) {
+            logger.warn("Could not get untracked files: ${e.message}")
+            emptySet()
+        }
     }
 
     private fun findGitRoot(startDir: File): File? {

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectFileMapper.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectFileMapper.kt
@@ -34,7 +34,9 @@ class ProjectFileMapper {
             // Normalize path separators to forward slashes for cross-platform compatibility
             val normalizedProjectPath = projectPath.replace('\\', '/')
 
-            // Add trailing slash for comparison
+            // An empty or "." path means this is the root project (its projectDir == rootDir).
+            // Use an empty string as the sentinel so isFileInProject() can identify it and
+            // apply root-project-specific matching logic (exclude files that belong to subprojects).
             val normalizedProjectPathWithSlash = if (normalizedProjectPath.isEmpty() || normalizedProjectPath == ".") "" else "$normalizedProjectPath/"
 
             changedFiles.forEach { file ->

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectsChangedExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectsChangedExtension.kt
@@ -7,7 +7,13 @@ import io.github.doughawley.monorepochangedprojects.domain.ProjectMetadata
  */
 open class ProjectsChangedExtension {
     /**
-     * The base branch to compare against (default: main)
+     * The base branch to compare against when detecting changed files.
+     * Defaults to "main" — override this if your repository uses a different
+     * primary branch name (e.g. "master", "develop", "trunk").
+     *
+     * Supports both local branch names (e.g. "main") and remote refs
+     * (e.g. "origin/main"). A local name is automatically prefixed with
+     * "origin/" before falling back to a local-only comparison.
      */
     var baseBranch: String = "main"
 


### PR DESCRIPTION
## Summary

Addresses all 6 low-severity issues identified in CODE_REVIEW.md in a single commit.

- **#9** — Add `logger.debug()` message when a project is excluded from the affected list due to a missing build file, making the omission diagnosable with `--debug`
- **#10** — Add try-catch to `getStagedFiles()` and `getUntrackedFiles()` to match the error-handling pattern used by `getWorkingTreeChanges()`, preventing unhandled exceptions from aborting change detection
- **#11** — Add `ProjectMetadataTest` case verifying deep dependency chains terminate correctly; note that true circular references are structurally impossible since `ProjectMetadata.dependencies` is a `val` on a data class
- **#12** — Add inline comment in `computeMetadata()` explaining that `":"` is Gradle's path for the root project and why it is excluded from the affected project list
- **#13** — Add explanatory comment in `ProjectFileMapper` clarifying the empty-string sentinel used to identify the root project in `isFileInProject()`
- **#14** — Expand KDoc on `ProjectsChangedExtension.baseBranch` to explicitly document the `"main"` default and provide override examples for other branch naming conventions

## Test plan

- [ ] Run `./gradlew check` to verify all existing tests pass
- [ ] Verify new `ProjectMetadataTest` case `hasChanges terminates correctly for deep dependency trees` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)