### PR TITLE
fix: Address all medium-severity code review issues (#4–#7)

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -28,22 +28,22 @@ Issues identified during code review. Severity: **high**, **medium**, **low**.
 ### 4. Regex compiled inside loop in `GitChangedFilesDetector`
 - **File**: `src/main/kotlin/.../GitChangedFilesDetector.kt` (lines 66–70)
 - **Issue**: `Regex(pattern)` is compiled for every file × every exclude pattern — O(n×m) with unnecessary garbage. Pre-compile patterns outside the loop.
-- **Status**: Open
+- **Status**: Fixed in `fix-medium-severity-issues` — patterns are now compiled once into `compiledExcludePatterns` before the filter loop.
 
 ### 5. No error handling for non-relative project paths in `ProjectFileMapper`
 - **File**: `src/main/kotlin/.../ProjectFileMapper.kt` (line 32)
 - **Issue**: `projectDir.relativeTo(rootDir)` throws if a subproject's directory is outside the root, with no clear error message for the user.
-- **Status**: Open
+- **Status**: Fixed in `fix-medium-severity-issues` — wrapped in try-catch that rethrows with a descriptive message including the offending project path and directories.
 
 ### 6. Confusing error message when metadata check fails in `buildChangedProjects`
 - **File**: `src/main/kotlin/.../MonorepoChangedProjectsPlugin.kt` (lines 86–111)
 - **Issue**: If metadata computation was skipped or failed silently, the resulting `IllegalStateException` doesn't surface the root cause.
-- **Status**: Open
+- **Status**: Fixed in `fix-medium-severity-issues` — error message now lists likely causes and directs the user to re-run with `--info` or `--debug`.
 
 ### 7. Git three-dot diff fallback may not work for local-only branches
 - **File**: `src/main/kotlin/.../GitChangedFilesDetector.kt` (lines 73–94)
 - **Issue**: `git diff "$baseBranch...HEAD"` doesn't work if the base branch has no remote tracking ref. Local-only branches need explicit handling.
-- **Status**: Open
+- **Status**: Fixed in `fix-medium-severity-issues` — replaced try-catch fallback with explicit `git rev-parse --verify` probing via `resolveBaseBranchRef()`. Preference order: remote ref → local ref → clear warning if neither exists.
 
 ### 8. No instance reuse for `GitCommandExecutor`
 - **File**: `src/main/kotlin/.../GitChangedFilesDetector.kt`, `ProjectMetadataFactory.kt`

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPlugin.kt
@@ -97,8 +97,10 @@ class MonorepoChangedProjectsPlugin : Plugin<Project> {
 
                 if (!extension.metadataComputed) {
                     throw IllegalStateException(
-                        "Changed project metadata was not computed in configuration phase. " +
-                        "This indicates a plugin initialization error."
+                        "Changed project metadata was not computed in the configuration phase. " +
+                        "Possible causes: the plugin was not applied to the root project, " +
+                        "or an error occurred during project evaluation. " +
+                        "Re-run with --info or --debug for more details."
                     )
                 }
 

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectFileMapper.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectFileMapper.kt
@@ -29,7 +29,16 @@ class ProjectFileMapper {
         val projectToFilesMap = mutableMapOf<String, MutableList<String>>()
 
         rootProject.allprojects.forEach { subproject ->
-            val projectPath = subproject.projectDir.relativeTo(rootProject.rootDir).path
+            val projectPath = try {
+                subproject.projectDir.relativeTo(rootProject.rootDir).path
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException(
+                    "Project '${subproject.path}' has a directory (${subproject.projectDir}) " +
+                    "that is not inside the root project directory (${rootProject.rootDir}). " +
+                    "All subproject directories must be located under the root project directory.",
+                    e
+                )
+            }
 
             // Normalize path separators to forward slashes for cross-platform compatibility
             val normalizedProjectPath = projectPath.replace('\\', '/')


### PR DESCRIPTION
## Summary

Addresses all 4 medium-severity issues from CODE_REVIEW.md in a single commit.

- **#4** — Pre-compile exclude patterns into `compiledExcludePatterns` before the filter loop in `GitChangedFilesDetector`, avoiding O(n×m) `Regex` object creation for every changed file × every pattern
- **#5** — Wrap `relativeTo()` in `ProjectFileMapper` with a try-catch that rethrows an `IllegalArgumentException` with a descriptive message including the offending project path and both directories when a subproject lives outside the root project directory
- **#6** — Improve the `IllegalStateException` message in `buildChangedProjects` to list likely root causes (plugin not applied to root, error during evaluation) and direct the user to `--info`/`--debug`
- **#7** — Replace the silent try-catch fallback in `getChangedFilesSinceBaseBranch` with explicit `git rev-parse --verify` probing via `resolveBaseBranchRef()`. Preference order: remote tracking ref (`origin/<branch>`) → local branch → clear warning if neither exists

## Tests added

- `should return empty set when base branch cannot be resolved as remote or local ref` — verifies issue #7 degrades gracefully for a non-existent branch
- `should not double-prefix base branch that already starts with origin/` — verifies issue #7 doesn't turn `origin/main` into `origin/origin/main`
- `should correctly apply multiple exclude patterns to many files` — verifies issue #4's pre-compiled filtering correctly excludes all matching file types

## Test plan

- [ ] Run `./gradlew check` to verify all existing and new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)