### PR TITLE
fix: Replace synchronized+extraProperties flag with AtomicBoolean.compareAndSet

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -14,7 +14,7 @@ Issues identified during code review. Severity: **high**, **medium**, **low**.
 ### 2. Race condition in plugin initialization
 - **File**: `src/main/kotlin/.../MonorepoChangedProjectsPlugin.kt` (lines 34–78)
 - **Issue**: The `synchronized(project.rootProject)` wrapper guards the check-and-set, but Gradle's `extraProperties` may not be thread-safe under the hood. An `AtomicBoolean` would be more explicit and reliable.
-- **Status**: Partially addressed in PR #26 (synchronized block added); AtomicBoolean refactor still pending
+- **Status**: Fully fixed in `fix-atomic-boolean-race-condition` — replaced `synchronized` + `extraProperties` string flag with `AtomicBoolean.compareAndSet` on `ProjectsChangedExtension`. `metadataComputed` marked `@Volatile` for cross-thread visibility.
 
 ### 3. Fragile reflection-based dependency unwrapping in `ProjectMetadataFactory`
 - **File**: `src/main/kotlin/.../ProjectMetadataFactory.kt` (lines 130–140)

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPlugin.kt
@@ -9,10 +9,6 @@ import org.gradle.api.Project
  */
 class MonorepoChangedProjectsPlugin : Plugin<Project> {
 
-    companion object {
-        private const val COMPUTED_FLAG_KEY = "monorepoChangedProjects.metadataComputed"
-    }
-
     override fun apply(project: Project) {
         // Register the extension on the root project to ensure it's shared
         val rootExtension = if (project == project.rootProject) {
@@ -29,51 +25,43 @@ class MonorepoChangedProjectsPlugin : Plugin<Project> {
                 )
         }
 
-        // Compute metadata in configuration phase after ALL projects are evaluated
-        // Use gradle.projectsEvaluated to ensure all subprojects are configured
-        // Use a flag on the gradle instance to ensure this only runs once
+        // Compute metadata in configuration phase after ALL projects are evaluated.
+        // Use gradle.projectsEvaluated to ensure all subprojects are configured.
+        // Under --parallel, multiple threads may fire this callback concurrently.
+        // computationGuard.compareAndSet(false, true) is an atomic check-and-set:
+        // only the first thread to win proceeds; all others see true and skip.
         project.gradle.projectsEvaluated {
-            // Synchronize on the root project to guard against parallel project configuration
-            // (--parallel) where multiple threads may register and fire this callback
-            // concurrently. The check-and-set must be atomic to ensure computeMetadata()
-            // runs exactly once.
-            synchronized(project.rootProject) {
-                val computed = project.gradle.extensions.extraProperties.has(COMPUTED_FLAG_KEY)
-                if (!computed) {
-                    // Mark as computed before running to prevent re-entry
-                    project.gradle.extensions.extraProperties.set(COMPUTED_FLAG_KEY, true)
+            if (rootExtension.computationGuard.compareAndSet(false, true)) {
+                try {
+                    computeMetadata(project.rootProject, rootExtension)
+                    rootExtension.metadataComputed = true
+                    project.logger.debug("Changed project metadata computed successfully in configuration phase")
 
-                    try {
-                        computeMetadata(project.rootProject, rootExtension)
-                        rootExtension.metadataComputed = true
-                        project.logger.debug("Changed project metadata computed successfully in configuration phase")
-
-                        // Wire up dependsOn for each affected project's build task now that we know
-                        // which projects changed. This must happen in the configuration phase so
-                        // Gradle can include them in the task graph before execution begins.
-                        val buildChangedTask = project.tasks.named("buildChangedProjects")
-                        rootExtension.allAffectedProjects.forEach { projectPath ->
-                            val targetProject = project.rootProject.findProject(projectPath)
-                            if (targetProject != null) {
-                                val buildTask = targetProject.tasks.findByName("build")
-                                if (buildTask != null) {
-                                    buildChangedTask.configure {
-                                        dependsOn(buildTask)
-                                    }
-                                } else {
-                                    project.logger.warn("No build task found for $projectPath")
+                    // Wire up dependsOn for each affected project's build task now that we know
+                    // which projects changed. This must happen in the configuration phase so
+                    // Gradle can include them in the task graph before execution begins.
+                    val buildChangedTask = project.tasks.named("buildChangedProjects")
+                    rootExtension.allAffectedProjects.forEach { projectPath ->
+                        val targetProject = project.rootProject.findProject(projectPath)
+                        if (targetProject != null) {
+                            val buildTask = targetProject.tasks.findByName("build")
+                            if (buildTask != null) {
+                                buildChangedTask.configure {
+                                    dependsOn(buildTask)
                                 }
                             } else {
-                                project.logger.warn("Project not found: $projectPath")
+                                project.logger.warn("No build task found for $projectPath")
                             }
+                        } else {
+                            project.logger.warn("Project not found: $projectPath")
                         }
-                    } catch (e: Exception) {
-                        // Fail-fast: metadata computation is critical
-                        throw IllegalStateException(
-                            "Failed to compute changed project metadata in configuration phase: ${e.message}",
-                            e
-                        )
                     }
+                } catch (e: Exception) {
+                    // Fail-fast: metadata computation is critical
+                    throw IllegalStateException(
+                        "Failed to compute changed project metadata in configuration phase: ${e.message}",
+                        e
+                    )
                 }
             }
         }

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectsChangedExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectsChangedExtension.kt
@@ -1,6 +1,7 @@
 package io.github.doughawley.monorepochangedprojects
 
 import io.github.doughawley.monorepochangedprojects.domain.ProjectMetadata
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Extension for configuring the monorepo-changed-projects plugin.
@@ -47,8 +48,17 @@ open class ProjectsChangedExtension {
     internal var changedFilesMap: Map<String, List<String>> = emptyMap()
 
     /**
+     * Guards against concurrent metadata computation under --parallel builds.
+     * The first thread to win compareAndSet(false, true) performs the computation;
+     * all others see true and skip it.
+     */
+    internal val computationGuard = AtomicBoolean(false)
+
+    /**
      * Flag indicating whether metadata has been computed in the configuration phase.
+     * Marked volatile to ensure the write is visible to all threads once set.
      * Used to ensure metadata is available before task execution.
      */
+    @Volatile
     internal var metadataComputed: Boolean = false
 }


### PR DESCRIPTION
## Summary

Fully resolves issue #2 from CODE_REVIEW.md — the race condition in plugin initialization.

The previous approach stored a string key in Gradle's `extraProperties` and used `synchronized(project.rootProject)` to guard the check-and-set. This relied on Gradle's `extraProperties` being thread-safe and on the project object being a reliable monitor.

**Changes:**
- Adds `computationGuard: AtomicBoolean` to `ProjectsChangedExtension`. `compareAndSet(false, true)` is an inherently atomic operation — only the first thread to win proceeds to call `computeMetadata()`; all others see `true` and skip without needing an outer lock
- Marks `metadataComputed` as `@Volatile` so the write is guaranteed to be visible to all threads once set, removing a potential stale-read hazard
- Removes the now-unused `COMPUTED_FLAG_KEY` string constant and the `synchronized` block

## Test plan

- [ ] Run `./gradlew check` to verify all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)