### PR TITLE
chore: upgrade com.gradle.plugin-publish to 2.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
     `maven-publish`
-    id("com.gradle.plugin-publish") version "1.3.0"
+    id("com.gradle.plugin-publish") version "2.0.0"
 }
 
 group = "io.github.doug-hawley"
@@ -90,8 +90,8 @@ tasks.withType<Test>().configureEach {
 }
 
 gradlePlugin {
-    website = "https://github.com/doug-hawley/monorepo-changed-projects-plugin"
-    vcsUrl = "https://github.com/doug-hawley/monorepo-changed-projects-plugin.git"
+    website.set("https://github.com/doug-hawley/monorepo-changed-projects-plugin")
+    vcsUrl.set("https://github.com/doug-hawley/monorepo-changed-projects-plugin.git")
 
     plugins {
         register("monorepoChangedProjectsPlugin") {
@@ -99,7 +99,7 @@ gradlePlugin {
             implementationClass = "io.github.doughawley.monorepochangedprojects.MonorepoChangedProjectsPlugin"
             displayName = "Monorepo Changed Projects Plugin"
             description = "A Gradle plugin to detect changed projects in a monorepo based on git history"
-            tags = listOf("monorepo", "git", "ci", "optimization", "build")
+            tags.set(listOf("monorepo", "git", "ci", "optimization", "build"))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Upgrades `com.gradle.plugin-publish` from `1.3.0` to `2.0.0`
- Migrates `website`, `vcsUrl`, and `tags` in the `gradlePlugin {}` block to the Provider API `.set()` form required by 2.0.0

## Why not Kotest 6?

Kotest 6.1.3 was compiled with Kotlin 2.2.0, but Gradle 8.12 bundles Kotlin 2.0.x (which can only read metadata up to 2.1.0). Upgrading Kotest 6.x requires Gradle 9 first — deferred to a future PR.

## Test plan

- [x] `./gradlew build unitTest functionalTest` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)