### PR TITLE
docs: automate README version bumps and fix stale content

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,11 @@
           "type": "generic",
           "path": "build.gradle.kts",
           "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "README.md",
+          "glob": false
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Adds `README.md` to release-please `extra-files` so version strings are bumped automatically on every release — no manual README edits needed after merging a release PR
- Annotates the two plugin application code blocks with `// x-release-please-version` markers so release-please knows exactly which lines to update
- Fixes stale/broken content in the README

## Content fixes

- **Broken code block**: Removed stray closing braces at the end of the `buildChangedApps` example (copy-paste artifact)
- **Invalid task registration**: The multi-module example was calling `tasks.register("buildChangedProjects")`, which would throw a runtime exception since the plugin already registers that task. Replaced with the correct usage pattern (`./gradlew buildChangedProjects`)
- **Version strings**: Updated `1.0.0` → `1.0.1` to match the current `.release-please-manifest.json`

## How the automation works

From this PR forward, when release-please opens its release PR it will:
1. Bump the version in `build.gradle.kts` (existing behaviour)
2. Also bump both `// x-release-please-version` lines in `README.md` to the new version

No further manual action is needed to keep the README version in sync.

## Test plan

- [x] README renders correctly on GitHub
- [x] All code examples are syntactically valid
- [x] `release-please-config.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)