### PR TITLE
ci: trigger CI on release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, "release-please**" ]
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Adds `"release-please**"` to the `on.push.branches` list in `ci.yml`

## Why

GitHub's `GITHUB_TOKEN` cannot trigger other workflow runs (security restriction to prevent loops). Release-please creates its PR using `GITHUB_TOKEN`, so CI never runs on it — blocking merges when branch protection requires passing checks.

By listening to `push` on the release-please branch pattern, CI runs automatically whenever release-please updates its branch, satisfying branch protection rules.

## Test plan

- [ ] Merge this PR
- [ ] Verify CI runs automatically on the next release-please PR update

🤖 Generated with [Claude Code](https://claude.com/claude-code)