### PR TITLE
feat: add per-project exclude patterns via projectExcludes extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,22 @@ This ensures that:
 |----------|------|---------|-------------|
 | `baseBranch` | String | `"main"` | The git branch to compare against |
 | `includeUntracked` | Boolean | `true` | Whether to include untracked files in detection |
-| `excludePatterns` | List<String> | `[]` | Regex patterns for files to exclude |
+| `excludePatterns` | List<String> | `[]` | Regex patterns for files to exclude globally |
+
+### Per-project excludes
+
+Individual subprojects can declare their own exclude patterns using the `projectExcludes` extension. This is useful when a team wants to ignore generated files or other noise that is specific to their module without cluttering the root configuration.
+
+```kotlin
+// In :api/build.gradle.kts
+projectExcludes {
+    excludePatterns = listOf("generated/.*", ".*\\.json")
+}
+```
+
+- Patterns are Java regex strings matched against file paths **relative to the subproject directory** (e.g., `generated/Code.kt`, not `api/generated/Code.kt`).
+- Per-project patterns are applied **after** global `excludePatterns`, so the two stages are independent and complementary.
+- The extension is automatically registered on all subprojects by the plugin — subprojects do not need to apply the plugin themselves.
 
 ## Troubleshooting
 

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectExcludesExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectExcludesExtension.kt
@@ -1,0 +1,17 @@
+package io.github.doughawley.monorepochangedprojects
+
+/**
+ * Per-project extension that allows individual subprojects to declare their own
+ * file exclude patterns. Patterns are applied after global excludePatterns and
+ * after file-to-project mapping, so they only affect files within the project.
+ *
+ * Usage in a subproject's build.gradle.kts:
+ * ```
+ * projectExcludes {
+ *     excludePatterns = listOf("generated/.*", ".*\\.json")
+ * }
+ * ```
+ */
+open class ProjectExcludesExtension {
+    var excludePatterns: List<String> = listOf()
+}

--- a/src/test/functional/kotlin/io/github/doughawley/monorepochangedprojects/functional/MonorepoPluginConfigurationTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepochangedprojects/functional/MonorepoPluginConfigurationTest.kt
@@ -1,0 +1,60 @@
+package io.github.doughawley.monorepochangedprojects.functional
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import org.gradle.testkit.runner.TaskOutcome
+
+/**
+ * Functional tests for plugin configuration options.
+ */
+class MonorepoPluginConfigurationTest : FunSpec({
+    val testProjectListener = listener(TestProjectListener())
+
+    test("per-project exclude patterns prevent project from being marked changed") {
+        // given: :api excludes generated files; :core has no excludes
+        val projectDir = testProjectListener.getTestProjectDir()
+        val project = TestProjectBuilder(projectDir)
+            .withSubproject("api", excludePatterns = listOf("generated/.*"))
+            .withSubproject("core")
+            .applyPlugin()
+            .build()
+        project.initGit()
+        project.commitAll("Initial commit")
+
+        // when: a file matching the :api exclude pattern is created (untracked)
+        project.createNewFile("api/generated/Code.kt", "// generated code")
+
+        val result = project.runTask("detectChangedProjects")
+
+        // then: :api is not considered changed because the only changed file is excluded
+        result.task(":detectChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changedProjects = result.extractChangedProjects()
+        changedProjects shouldNotContain ":api"
+    }
+
+    test("per-project excludes only apply to their own project, not others") {
+        // given: :api excludes generated files; :core has no excludes
+        val projectDir = testProjectListener.getTestProjectDir()
+        val project = TestProjectBuilder(projectDir)
+            .withSubproject("api", excludePatterns = listOf("generated/.*"))
+            .withSubproject("core")
+            .applyPlugin()
+            .build()
+        project.initGit()
+        project.commitAll("Initial commit")
+
+        // when: matching files are created in both :api and :core (both untracked)
+        project.createNewFile("api/generated/Code.kt", "// generated code")
+        project.createNewFile("core/generated/Stub.kt", "// generated stub")
+
+        val result = project.runTask("detectChangedProjects")
+
+        // then: :api is excluded (pattern matches), :core is detected (no pattern)
+        result.task(":detectChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changedProjects = result.extractChangedProjects()
+        changedProjects shouldNotContain ":api"
+        changedProjects shouldContain ":core"
+    }
+})

--- a/src/test/functional/kotlin/io/github/doughawley/monorepochangedprojects/functional/TestProjectBuilder.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepochangedprojects/functional/TestProjectBuilder.kt
@@ -17,16 +17,18 @@ class TestProjectBuilder(private val projectDir: File) {
         val name: String,
         val dependencies: List<String> = emptyList(),
         val isBom: Boolean = false,
-        val usePlatform: Boolean = false
+        val usePlatform: Boolean = false,
+        val excludePatterns: List<String> = emptyList()
     )
 
     fun withSubproject(
         name: String,
         dependsOn: List<String> = emptyList(),
         isBom: Boolean = false,
-        usePlatform: Boolean = false
+        usePlatform: Boolean = false,
+        excludePatterns: List<String> = emptyList()
     ): TestProjectBuilder {
-        subprojects.add(SubprojectConfig(name, dependsOn, isBom, usePlatform))
+        subprojects.add(SubprojectConfig(name, dependsOn, isBom, usePlatform, excludePatterns))
         return this
     }
 
@@ -126,6 +128,12 @@ class TestProjectBuilder(private val projectDir: File) {
                         }
                     }
 
+                    appendLine("}")
+                }
+                if (subproject.excludePatterns.isNotEmpty()) {
+                    appendLine()
+                    appendLine("projectExcludes {")
+                    appendLine("    excludePatterns = listOf(${subproject.excludePatterns.joinToString { "\"$it\"" }})")
                     appendLine("}")
                 }
             }


### PR DESCRIPTION
Registers a ProjectExcludesExtension on every subproject so teams can declare file exclusions locally in their own build.gradle.kts without touching the root configuration. Per-project patterns are applied after global excludePatterns and after file-to-project mapping, keeping the two filter stages independent.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements

## Changes Made
<!-- List the main changes in this PR -->

- 
- 
- 

## Testing
<!-- Describe how you tested your changes -->

- [ ] Unit tests added/updated
- [ ] Functional tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass locally

## Checklist
<!-- Review the checklist before submitting -->

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (README.md, CHANGELOG.md)
- [ ] No new warnings introduced
- [ ] Tests cover the changes
- [ ] All tests pass (`./gradlew check`)
- [ ] Git operations use ProcessBuilder with exit code checks
- [ ] Paths are normalized for comparison
- [ ] KDoc added for public APIs

## Related Issues
<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes
<!-- Any additional information reviewers should know -->
