### PR TITLE
feat: expose extension API for downstream task access

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,11 @@
           "type": "generic",
           "path": "README.md",
           "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "examples/access-changed-files.gradle.kts",
+          "glob": false
         }
       ]
     }

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPlugin.kt
@@ -88,8 +88,6 @@ class MonorepoChangedProjectsPlugin : Plugin<Project> {
         project.tasks.register("buildChangedProjects").configure {
             group = "build"
             description = "Builds only the projects that have been affected by changes"
-            dependsOn("printChangedProjects")
-
             doLast {
                 val extension = project.rootProject.extensions.getByType(ProjectsChangedExtension::class.java)
 

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/PrintChangedProjectsTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/PrintChangedProjectsTask.kt
@@ -33,20 +33,12 @@ abstract class PrintChangedProjectsTask : DefaultTask() {
         }
 
         // Read pre-computed metadata from configuration phase
-        val metadataMap = extension.metadataMap
-        val allAffectedProjects = extension.allAffectedProjects
-        val changedFilesMap = extension.changedFilesMap
-        val directlyChangedProjects = changedFilesMap.keys
+        val directlyChangedProjects = extension.changedFilesMap.keys
 
         val directlyChangedList = if (directlyChangedProjects.isEmpty()) "" else directlyChangedProjects.joinToString(", ")
         logger.lifecycle("Directly changed projects: $directlyChangedList")
 
-        val allAffectedList = if (allAffectedProjects.isEmpty()) "" else allAffectedProjects.joinToString(", ")
+        val allAffectedList = if (extension.allAffectedProjects.isEmpty()) "" else extension.allAffectedProjects.joinToString(", ")
         logger.lifecycle("All affected projects (including dependents): $allAffectedList")
-
-        // Store results in project extra properties for backward compatibility
-        project.extensions.extraProperties.set("changedProjects", allAffectedProjects)
-        project.extensions.extraProperties.set("changedProjectsMetadata", metadataMap)
-        project.extensions.extraProperties.set("changedFilesMap", changedFilesMap)
     }
 }

--- a/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectsChangedExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepochangedprojects/ProjectsChangedExtension.kt
@@ -33,19 +33,22 @@ open class ProjectsChangedExtension {
      * Maps project paths to their metadata including dependencies and changed files.
      * Available after configuration phase completes.
      */
-    internal var metadataMap: Map<String, ProjectMetadata> = emptyMap()
+    var metadataMap: Map<String, ProjectMetadata> = emptyMap()
+        internal set
 
     /**
      * Set of all affected project paths (including those affected by dependency changes).
      * Available after configuration phase completes.
      */
-    internal var allAffectedProjects: Set<String> = emptySet()
+    var allAffectedProjects: Set<String> = emptySet()
+        internal set
 
     /**
      * Map of changed files by project path.
      * Available after configuration phase completes.
      */
-    internal var changedFilesMap: Map<String, List<String>> = emptyMap()
+    var changedFilesMap: Map<String, List<String>> = emptyMap()
+        internal set
 
     /**
      * Guards against concurrent metadata computation under --parallel builds.

--- a/src/test/unit/kotlin/io/github/doughawley/monorepochangedprojects/BuildChangedProjectsTaskTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepochangedprojects/BuildChangedProjectsTaskTest.kt
@@ -1,7 +1,6 @@
 package io.github.doughawley.monorepochangedprojects
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.gradle.testfixtures.ProjectBuilder
@@ -20,107 +19,5 @@ class BuildChangedProjectsTaskTest : FunSpec({
         task shouldNotBe null
         task?.group shouldBe "build"
         task?.description shouldBe "Builds only the projects that have been affected by changes"
-    }
-
-    test("buildChangedProjects should have printChangedProjects as dependency") {
-        // given
-        val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply("io.github.doug-hawley.monorepo-changed-projects-plugin")
-
-        // when
-        val task = project.tasks.findByName("buildChangedProjects")
-
-        // then - verify dependency is set up
-        task shouldNotBe null
-        val dependencies = task?.taskDependencies?.getDependencies(task)?.map { it.name }
-        dependencies shouldNotBe null
-        dependencies!! shouldContain "printChangedProjects"
-    }
-
-    test("safe casting logic should handle null property") {
-        // Test the safe casting pattern directly
-        val testMap = mutableMapOf<String, Any?>()
-        testMap["changedProjects"] = null
-
-        // This is the pattern used in the fix - should not throw
-        val changedProjectsRaw = testMap["changedProjects"] as? Set<*>
-        changedProjectsRaw shouldBe null
-
-        // If null, should filter to empty
-        val changedProjects = changedProjectsRaw?.filterIsInstance<String>()?.toSet() ?: emptySet()
-        changedProjects shouldBe emptySet<String>()
-    }
-
-    test("safe casting logic should handle wrong type") {
-        // Test the safe casting pattern with wrong type
-        val testMap = mutableMapOf<String, Any?>()
-        testMap["changedProjects"] = listOf("project1", "project2") // Wrong type: List instead of Set
-
-        // This is the pattern used in the fix - should not throw
-        val changedProjectsRaw = testMap["changedProjects"] as? Set<*>
-        changedProjectsRaw shouldBe null // Cast fails, returns null
-
-        // If null, should filter to empty
-        val changedProjects = changedProjectsRaw?.filterIsInstance<String>()?.toSet() ?: emptySet()
-        changedProjects shouldBe emptySet<String>()
-    }
-
-    test("safe casting logic should handle valid Set<String>") {
-        // Test the safe casting pattern with correct type
-        val testMap = mutableMapOf<String, Any?>()
-        testMap["changedProjects"] = setOf(":project1", ":project2")
-
-        // This is the pattern used in the fix
-        val changedProjectsRaw = testMap["changedProjects"] as? Set<*>
-        changedProjectsRaw shouldNotBe null
-
-        // Should successfully filter and convert
-        val changedProjects = changedProjectsRaw?.filterIsInstance<String>()?.toSet() ?: emptySet()
-        changedProjects shouldBe setOf(":project1", ":project2")
-    }
-
-    test("safe casting logic should handle Set with mixed types") {
-        // Test the safe casting pattern with mixed types in Set
-        val testMap = mutableMapOf<String, Any?>()
-        testMap["changedProjects"] = setOf(":project1", 123, ":project2") // Mixed types
-
-        // This is the pattern used in the fix
-        val changedProjectsRaw = testMap["changedProjects"] as? Set<*>
-        changedProjectsRaw shouldNotBe null
-
-        // Should filter out non-Strings
-        val changedProjects = changedProjectsRaw?.filterIsInstance<String>()?.toSet() ?: emptySet()
-        changedProjects shouldBe setOf(":project1", ":project2")
-    }
-
-    test("buildChangedProjects should handle missing changedProjects property gracefully") {
-        // given
-        val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply("io.github.doug-hawley.monorepo-changed-projects-plugin")
-
-        // when - property is not set (printChangedProjects didn't run)
-        val task = project.tasks.findByName("buildChangedProjects")
-        task shouldNotBe null
-
-        // Verify the property doesn't exist yet
-        val hasProperty = project.extensions.extraProperties.has("changedProjects")
-        hasProperty shouldBe false
-    }
-
-    test("buildChangedProjects should validate property exists before accessing") {
-        // given
-        val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply("io.github.doug-hawley.monorepo-changed-projects-plugin")
-
-        // Set up the property
-        project.extensions.extraProperties.set("changedProjects", setOf(":subproject"))
-
-        // when
-        val hasProperty = project.extensions.extraProperties.has("changedProjects")
-
-        // then
-        hasProperty shouldBe true
-        val changedProjects = project.extensions.extraProperties.get("changedProjects") as? Set<*>
-        changedProjects shouldNotBe null
     }
 })

--- a/src/test/unit/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPluginTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepochangedprojects/MonorepoChangedProjectsPluginTest.kt
@@ -93,8 +93,8 @@ class MonorepoChangedProjectsPluginTest : FunSpec({
             task.detectChanges()
 
             // then
-            val changedProjects = project.extensions.extraProperties.get("changedProjects") as Set<String>
-            changedProjects shouldBe emptySet()
+            val extension = project.extensions.getByType(ProjectsChangedExtension::class.java)
+            extension.allAffectedProjects shouldBe emptySet()
         } finally {
             tempDir.deleteRecursively()
         }


### PR DESCRIPTION
Results are computed during the configuration phase and stored on the projectsChanged extension. Downstream tasks can now read allAffectedProjects, changedFilesMap, and metadataMap directly without depending on printChangedProjects.

- Make extension properties publicly readable (internal set)
- Remove extra properties writes from PrintChangedProjectsTask
- Remove dependsOn("printChangedProjects") from buildChangedProjects
- Update README and examples to use extension API
- Add examples/access-changed-files.gradle.kts to release-please version tracking

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements

## Changes Made
<!-- List the main changes in this PR -->

- 
- 
- 

## Testing
<!-- Describe how you tested your changes -->

- [ ] Unit tests added/updated
- [ ] Functional tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass locally

## Checklist
<!-- Review the checklist before submitting -->

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (README.md, CHANGELOG.md)
- [ ] No new warnings introduced
- [ ] Tests cover the changes
- [ ] All tests pass (`./gradlew check`)
- [ ] Git operations use ProcessBuilder with exit code checks
- [ ] Paths are normalized for comparison
- [ ] KDoc added for public APIs

## Related Issues
<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes
<!-- Any additional information reviewers should know -->
