### PR TITLE
refactor!: rename tasks to printChangedProjectsFromBranch and buildChangedProjectsFromBranch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,7 +345,7 @@ mkdir test-project
 cd test-project
 git init
 # Create build.gradle.kts with your plugin
-./gradlew printChangedProjects
+./gradlew printChangedProjectsFromBranch
 ```
 
 ### Debugging
@@ -353,7 +353,7 @@ git init
 Run Gradle with debug logging:
 
 ```bash
-./gradlew printChangedProjects --debug
+./gradlew printChangedProjectsFromBranch --debug
 ```
 
 Run tests with IntelliJ IDEA debugger:

--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ monorepoBuild {
 ### Run the detection task
 
 ```bash
-./gradlew printChangedProjects
+./gradlew printChangedProjectsFromBranch
 ```
 
 ### Build only changed projects
 
-The plugin registers a `buildChangedProjects` task that automatically builds only the projects affected by changes:
+The plugin registers a `buildChangedProjectsFromBranch` task that automatically builds only the projects affected by changes:
 
 ```bash
-./gradlew buildChangedProjects
+./gradlew buildChangedProjectsFromBranch
 ```
 
 This task will:
@@ -199,10 +199,10 @@ Then run the built-in tasks:
 
 ```bash
 # Detect and print which projects changed
-./gradlew printChangedProjects
+./gradlew printChangedProjectsFromBranch
 
 # Build only the affected projects
-./gradlew buildChangedProjects
+./gradlew buildChangedProjectsFromBranch
 ```
 
 ### CI/CD Integration
@@ -357,7 +357,7 @@ This can happen if:
 Solution:
 ```bash
 git fetch origin
-./gradlew printChangedProjects
+./gradlew printChangedProjectsFromBranch
 ```
 
 ### No projects detected despite changes
@@ -365,7 +365,7 @@ git fetch origin
 Check your `excludePatterns` configuration - you may be inadvertently excluding files. Enable logging to see what files are being detected:
 
 ```bash
-./gradlew printChangedProjects --info
+./gradlew printChangedProjectsFromBranch --info
 ```
 
 ### Root project always shows as changed

--- a/examples/access-changed-files.gradle.kts
+++ b/examples/access-changed-files.gradle.kts
@@ -11,7 +11,7 @@ monorepoBuild {
 }
 
 // The plugin computes results during the configuration phase, so any task can read
-// from the extension directly — no dependsOn("printChangedProjects") needed.
+// from the extension directly — no dependsOn("printChangedProjectsFromBranch") needed.
 
 // Example 1: Simple - Just list changed projects
 tasks.register("listChangedProjects") {

--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPlugin.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPlugin.kt
@@ -50,7 +50,7 @@ class MonorepoBuildPlugin : Plugin<Project> {
                     // Wire up dependsOn for each affected project's build task now that we know
                     // which projects changed. This must happen in the configuration phase so
                     // Gradle can include them in the task graph before execution begins.
-                    val buildChangedTask = project.tasks.named("buildChangedProjects")
+                    val buildChangedTask = project.tasks.named("buildChangedProjectsFromBranch")
                     rootExtension.allAffectedProjects.forEach { projectPath ->
                         val targetProject = project.rootProject.findProject(projectPath)
                         if (targetProject != null) {
@@ -76,16 +76,16 @@ class MonorepoBuildPlugin : Plugin<Project> {
             }
         }
 
-        // Register the printChangedProjects task
-        project.tasks.register("printChangedProjects", PrintChangedProjectsTask::class.java).configure {
+        // Register the printChangedProjectsFromBranch task
+        project.tasks.register("printChangedProjectsFromBranch", PrintChangedProjectsTask::class.java).configure {
             group = "verification"
             description = "Detects which projects have changed based on git history"
         }
 
-        // Register the buildChangedProjects task.
+        // Register the buildChangedProjectsFromBranch task.
         // Actual dependsOn wiring for affected project build tasks is added dynamically
         // in the projectsEvaluated hook above, after changed projects are known.
-        project.tasks.register("buildChangedProjects").configure {
+        project.tasks.register("buildChangedProjectsFromBranch").configure {
             group = "build"
             description = "Builds only the projects that have been affected by changes"
             doLast {

--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/BuildChangedProjectsFunctionalTest.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/BuildChangedProjectsFunctionalTest.kt
@@ -12,12 +12,12 @@ import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.TaskOutcome
 
 /**
- * Functional tests for the buildChangedProjects task.
+ * Functional tests for the buildChangedProjectsFromBranch task.
  */
 class BuildChangedProjectsFunctionalTest : FunSpec({
     val testProjectListener = listener(TestProjectListener())
 
-    test("buildChangedProjects task builds only affected projects") {
+    test("buildChangedProjectsFromBranch task builds only affected projects") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
@@ -26,10 +26,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change common-lib")
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
         // Assert
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         // Should build common-lib and all its dependents
         val builtProjects = result.extractBuiltProjects()
@@ -42,7 +42,7 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
     }
 
-    test("buildChangedProjects builds only affected apps when module changes") {
+    test("buildChangedProjectsFromBranch builds only affected apps when module changes") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
@@ -51,31 +51,31 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change module1")
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
         // Assert
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContainAll setOf(Projects.MODULE1, Projects.APP1)
         builtProjects shouldNotContain Projects.APP2  // app2 doesn't depend on module1
     }
 
-    test("buildChangedProjects reports no changes when nothing modified") {
+    test("buildChangedProjectsFromBranch reports no changes when nothing modified") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
         // Don't make any changes
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
         // Assert
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "No projects have changed - nothing to build"
     }
 
-    test("buildChangedProjects handles multiple independent app changes") {
+    test("buildChangedProjectsFromBranch handles multiple independent app changes") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
@@ -85,16 +85,16 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change both apps")
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
         // Assert
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContainAll setOf(Projects.APP1, Projects.APP2)
     }
 
-    test("buildChangedProjects succeeds without running printChangedProjects") {
+    test("buildChangedProjectsFromBranch succeeds without running printChangedProjectsFromBranch") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
@@ -102,14 +102,14 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change module2")
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
-        // Assert - buildChangedProjects runs independently; printChangedProjects is not triggered
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.task(":printChangedProjects") shouldBe null
+        // Assert - buildChangedProjectsFromBranch runs independently; printChangedProjectsFromBranch is not triggered
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch") shouldBe null
     }
 
-    test("buildChangedProjects builds only leaf project when changed") {
+    test("buildChangedProjectsFromBranch builds only leaf project when changed") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
@@ -118,10 +118,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change app2")
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
         // Assert
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContain Projects.APP2
@@ -131,7 +131,7 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         builtProjects shouldNotContain Projects.APP1
     }
 
-    test("buildChangedProjects builds projects affected by BOM changes") {
+    test("buildChangedProjectsFromBranch builds projects affected by BOM changes") {
         // Setup
         val project = testProjectListener.createStandardProject()
 
@@ -140,10 +140,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Bump BOM version")
 
         // Execute
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChangedProjectsFromBranch")
 
         // Assert
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         // Should build all projects that depend on the BOM
         val builtProjects = result.extractBuiltProjects()
@@ -166,10 +166,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Update BOM")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         // BOM changed, so all projects that depend on it should be affected
@@ -198,10 +198,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Update BOM and common-lib")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         // All projects affected (BOM affects all, common-lib also changed)

--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/MonorepoPluginConfigurationTest.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/MonorepoPluginConfigurationTest.kt
@@ -26,10 +26,10 @@ class MonorepoPluginConfigurationTest : FunSpec({
         // when: a file matching the :api exclude pattern is created (untracked)
         project.createNewFile("api/generated/Code.kt", "// generated code")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // then: :api is not considered changed because the only changed file is excluded
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldNotContain ":api"
     }
@@ -49,10 +49,10 @@ class MonorepoPluginConfigurationTest : FunSpec({
         project.createNewFile("api/generated/Code.kt", "// generated code")
         project.createNewFile("core/generated/Stub.kt", "// generated stub")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // then: :api is excluded (pattern matches), :core is detected (no pattern)
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldNotContain ":api"
         changedProjects shouldContain ":core"

--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/MonorepoPluginFunctionalTest.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/MonorepoPluginFunctionalTest.kt
@@ -26,10 +26,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change common-lib")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 5  // common-lib + all dependents
@@ -55,10 +55,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change module1")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 2  // module1 and app1 (not app2)
@@ -74,10 +74,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change module2")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 3  // module2, app1, app2
@@ -93,10 +93,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change app1")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 1
@@ -110,10 +110,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         // Don't make any changes
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         result.extractDirectlyChangedProjects() shouldBe emptySet()
         result.extractChangedProjects() shouldBe emptySet()
@@ -129,10 +129,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change both apps")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 2
@@ -153,10 +153,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         )
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         // common-lib changed, so all dependents affected
@@ -178,10 +178,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.stageFile(Files.MODULE1_SOURCE)
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldContainAll setOf(Projects.MODULE1, Projects.APP1)
@@ -196,10 +196,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change build config")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldContainAll setOf(Projects.MODULE2, Projects.APP1, Projects.APP2)
@@ -214,7 +214,7 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.commitAll("Change module2")
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
         val changedProjects = result.extractChangedProjects()
@@ -250,9 +250,9 @@ class MonorepoPluginFunctionalTest : FunSpec({
         )
         project.commitAll("Change billing api")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContain ":services:billing:api"
     }
@@ -266,9 +266,9 @@ class MonorepoPluginFunctionalTest : FunSpec({
         )
         project.commitAll("Change billing api")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContainAll setOf(
             ":services:billing:api",
@@ -287,9 +287,9 @@ class MonorepoPluginFunctionalTest : FunSpec({
         )
         project.commitAll("Change payments gateway")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContainAll setOf(":services:payments:gateway", ":apps:web")
         changed shouldNotContain ":services:billing:api"
@@ -305,9 +305,9 @@ class MonorepoPluginFunctionalTest : FunSpec({
         )
         project.commitAll("Change billing impl")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldBe setOf(":services:billing:impl")
     }
@@ -321,7 +321,7 @@ class MonorepoPluginFunctionalTest : FunSpec({
         )
         project.commitAll("Change gateway")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         val changed = result.extractChangedProjects()
         changed shouldContain ":services:payments:gateway"
@@ -340,10 +340,10 @@ class MonorepoPluginFunctionalTest : FunSpec({
         project.stageFile(Files.APP2_SOURCE)
 
         // Execute
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChangedProjectsFromBranch")
 
         // Assert
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromBranch")?.outcome shouldBe TaskOutcome.SUCCESS
 
         val changedProjects = result.extractChangedProjects()
         // common-lib affects all projects, app2 adds itself

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/BuildChangedProjectsTaskTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/BuildChangedProjectsTaskTest.kt
@@ -7,7 +7,7 @@ import org.gradle.testfixtures.ProjectBuilder
 
 class BuildChangedProjectsTaskTest : FunSpec({
 
-    test("buildChangedProjects task should be registered") {
+    test("buildChangedProjectsFromBranch task should be registered") {
         // given
         val project = ProjectBuilder.builder().build()
 
@@ -15,7 +15,7 @@ class BuildChangedProjectsTaskTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-plugin")
 
         // then
-        val task = project.tasks.findByName("buildChangedProjects")
+        val task = project.tasks.findByName("buildChangedProjectsFromBranch")
         task shouldNotBe null
         task?.group shouldBe "build"
         task?.description shouldBe "Builds only the projects that have been affected by changes"

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPluginTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPluginTest.kt
@@ -16,7 +16,7 @@ class MonorepoBuildPluginTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-plugin")
 
         // then
-        val task = project.tasks.findByName("printChangedProjects")
+        val task = project.tasks.findByName("printChangedProjectsFromBranch")
         task shouldNotBe null
         task.shouldBeInstanceOf<PrintChangedProjectsTask>()
     }
@@ -71,7 +71,7 @@ class MonorepoBuildPluginTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-plugin")
 
         // when
-        val task = project.tasks.findByName("printChangedProjects")
+        val task = project.tasks.findByName("printChangedProjectsFromBranch")
 
         // then
         task shouldNotBe null
@@ -87,7 +87,7 @@ class MonorepoBuildPluginTest : FunSpec({
                 .withProjectDir(tempDir)
                 .build()
             project.pluginManager.apply("io.github.doug-hawley.monorepo-build-plugin")
-            val task = project.tasks.findByName("printChangedProjects") as PrintChangedProjectsTask
+            val task = project.tasks.findByName("printChangedProjectsFromBranch") as PrintChangedProjectsTask
 
             // when
             task.detectChanges()


### PR DESCRIPTION
## Summary

- Renames `printChangedProjects` → `printChangedProjectsFromBranch`
- Renames `buildChangedProjects` → `buildChangedProjectsFromBranch`
- Updates all tests, docs, and examples to match

This establishes the `FromBranch` naming convention ahead of the upcoming `FromRef` counterpart tasks (issue #42). The new names make it explicit that these tasks detect changes relative to a configured base branch.

**BREAKING CHANGE**: task names have changed — users will need to update their Gradle invocations.

## Test plan

- [x] `./gradlew :monorepo-build-plugin:build` passes (unit + functional tests)
- [ ] Verify `./gradlew printChangedProjectsFromBranch` works in a local test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)