### PR TITLE
fix: fail fast with clear error when configuration cache is requested

### DIFF
--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/MonorepoPluginConfigurationTest.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/MonorepoPluginConfigurationTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.TaskOutcome
 
 /**
@@ -56,5 +57,17 @@ class MonorepoPluginConfigurationTest : FunSpec({
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldNotContain ":api"
         changedProjects shouldContain ":core"
+    }
+
+    test("plugin fails with helpful error when configuration cache is requested") {
+        // given: a standard project with the plugin applied
+        val project = testProjectListener.createStandardProject()
+
+        // when: a task is run with --configuration-cache enabled
+        val result = project.runTaskAndFail("printChangedProjectsFromBranch", "--configuration-cache")
+
+        // then: the build fails with a clear incompatibility message pointing to the fix
+        result.output shouldContain "monorepo-build-plugin is incompatible with the Gradle configuration cache"
+        result.output shouldContain "org.gradle.configuration-cache=false"
     }
 })


### PR DESCRIPTION
## Summary

- Injects `BuildFeatures` into `MonorepoBuildPlugin` via `@Inject` constructor and throws a `GradleException` at `apply()` time if the Gradle configuration cache is requested
- Uses the `BuildFeatures.configurationCache.requested` API (Gradle 8.5+) rather than the deprecated `StartParameter.isConfigurationCacheRequested`
- Adds a functional test asserting the error message and fix hint appear in the build output

## Motivation

The plugin executes git commands during the configuration phase (`projectsEvaluated`). With the configuration cache enabled, Gradle skips the configuration phase on subsequent builds, which would silently return stale changed-file data. This change makes the incompatibility explicit rather than silent.

The full fix (refactoring git calls to use Gradle's `ValueSource` API so the plugin becomes configuration cache compatible) is tracked in #49.

## Test plan

- [ ] New functional test `plugin fails with helpful error when configuration cache is requested` passes locally
- [ ] All existing functional and unit tests continue to pass
- [ ] CI passes across all matrix configurations (ubuntu/macOS × Java 17/21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)