### PR TITLE
feat: add printChangedProjectsFromRef and buildChangedProjectsFromRef tasks

### DIFF
--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildExtension.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildExtension.kt
@@ -19,6 +19,13 @@ open class MonorepoBuildExtension {
     var baseBranch: String = "main"
 
     /**
+     * An explicit commit ref (SHA, tag, or branch name) to compare against HEAD
+     * when using ref-mode tasks (printChangedProjectsFromRef, buildChangedProjectsFromRef).
+     * Can also be supplied at runtime via -PmonorepoBuild.commitRef=<sha>.
+     */
+    var commitRef: String? = null
+
+    /**
      * Whether to include untracked files in the change detection
      */
     var includeUntracked: Boolean = true

--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/PrintChangedProjectsFromRefTask.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/PrintChangedProjectsFromRefTask.kt
@@ -1,0 +1,99 @@
+package io.github.doughawley.monorepobuild
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Task that prints which projects have changed since a specific commit ref.
+ *
+ * Output format:
+ *   - Directly changed projects are listed with their changed files (relative to the project directory).
+ *   - Transitively affected projects are listed with an "(affected via ...)" annotation naming
+ *     the direct dependencies that carry the change.
+ *   - File lists are capped at FILE_DISPLAY_LIMIT entries.
+ */
+abstract class PrintChangedProjectsFromRefTask : DefaultTask() {
+
+    @TaskAction
+    fun detectChanges() {
+        val extension = project.rootProject.extensions.getByType(MonorepoBuildExtension::class.java)
+
+        if (!extension.metadataComputed) {
+            throw GradleException(
+                "Changed project metadata was not computed in the configuration phase. " +
+                "Possible causes: the plugin was not applied to the root project, " +
+                "or an error occurred during project evaluation. " +
+                "Re-run with --info or --debug for more details."
+            )
+        }
+
+        val resolvedRef = extension.commitRef ?: "(unknown ref)"
+        val allAffected = extension.allAffectedProjects
+
+        if (allAffected.isEmpty()) {
+            logger.lifecycle("No projects have changed.")
+            return
+        }
+
+        val directlyChanged = extension.changedFilesMap.keys
+            .filter { it in allAffected }
+            .sorted()
+
+        val transitivelyAffected = allAffected
+            .filter { it !in extension.changedFilesMap.keys }
+            .sorted()
+
+        val sb = StringBuilder()
+        sb.appendLine("Changed projects (since $resolvedRef):")
+
+        directlyChanged.forEach { projectPath ->
+            sb.appendLine()
+            sb.appendLine("  $projectPath")
+            val files = buildDisplayFiles(projectPath, extension.changedFilesMap)
+            files.take(FILE_DISPLAY_LIMIT).forEach { sb.appendLine("    - $it") }
+            if (files.size > FILE_DISPLAY_LIMIT) {
+                sb.appendLine("    ... and ${files.size - FILE_DISPLAY_LIMIT} more")
+            }
+        }
+
+        if (transitivelyAffected.isNotEmpty()) {
+            sb.appendLine()
+            val maxPathLen = transitivelyAffected.maxOf { it.length }
+            transitivelyAffected.forEach { projectPath ->
+                val via = extension.metadataMap[projectPath]
+                    ?.dependencies
+                    ?.filter { it.hasChanges() }
+                    ?.map { it.fullyQualifiedName }
+                    ?.sorted()
+                    ?.joinToString(", ")
+                    .orEmpty()
+                val annotation = if (via.isNotEmpty()) "  (affected via $via)" else ""
+                sb.appendLine("  ${projectPath.padEnd(maxPathLen)}$annotation")
+            }
+        }
+
+        logger.lifecycle(sb.toString().trimEnd())
+    }
+
+    private fun buildDisplayFiles(projectPath: String, changedFilesMap: Map<String, List<String>>): List<String> {
+        val files = changedFilesMap[projectPath].orEmpty()
+        val projectDir = project.rootProject.findProject(projectPath)
+            ?.projectDir
+            ?.relativeTo(project.rootProject.rootDir)
+            ?.path
+            ?.replace('\\', '/')
+            .orEmpty()
+        return files.map { file ->
+            if (projectDir.isNotEmpty() && file.startsWith("$projectDir/")) {
+                file.removePrefix("$projectDir/")
+            } else {
+                file
+            }
+        }.sorted()
+    }
+
+    companion object {
+        internal const val FILE_DISPLAY_LIMIT = 50
+    }
+}

--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/BuildChangedProjectsFromRefFunctionalTest.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/BuildChangedProjectsFromRefFunctionalTest.kt
@@ -1,0 +1,125 @@
+package io.github.doughawley.monorepobuild.functional
+
+import io.github.doughawley.monorepobuild.functional.StandardTestProject.Files
+import io.github.doughawley.monorepobuild.functional.StandardTestProject.Projects
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+
+/**
+ * Functional tests for the buildChangedProjectsFromRef task.
+ */
+class BuildChangedProjectsFromRefFunctionalTest : FunSpec({
+    val testProjectListener = listener(TestProjectListener())
+
+    test("buildChangedProjectsFromRef fails with helpful error when no commitRef provided") {
+        // given
+        val project = testProjectListener.createStandardProject()
+
+        // when: run without commitRef
+        val result = project.runTaskAndFail("buildChangedProjectsFromRef")
+
+        // then: error message mentions how to supply commitRef
+        result.output shouldContain "commitRef"
+        result.output shouldContain "monorepoBuild.commitRef"
+    }
+
+    test("buildChangedProjectsFromRef builds directly changed project") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        project.appendToFile(Files.APP2_SOURCE, "\n// Modified")
+        project.commitAll("Modify app2")
+
+        // when
+        val result = project.runTaskWithProperties(
+            "buildChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then
+        result.task(":buildChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        val built = result.extractBuiltProjectsFromRef()
+        built shouldContain Projects.APP2
+        built shouldNotContain Projects.COMMON_LIB
+        built shouldNotContain Projects.MODULE1
+    }
+
+    test("buildChangedProjectsFromRef builds all projects affected by common-lib change") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Modified")
+        project.commitAll("Modify common-lib")
+
+        // when
+        val result = project.runTaskWithProperties(
+            "buildChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then: common-lib plus all transitive dependents are built
+        result.task(":buildChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        val built = result.extractBuiltProjectsFromRef()
+        built shouldContainAll setOf(
+            Projects.COMMON_LIB,
+            Projects.MODULE1,
+            Projects.MODULE2,
+            Projects.APP1,
+            Projects.APP2
+        )
+    }
+
+    test("buildChangedProjectsFromRef reports no changes when nothing modified since ref") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val headSha = project.getLastCommitSha()
+
+        // when: compare HEAD against itself — no changes
+        val result = project.runTaskWithProperties(
+            "buildChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to headSha)
+        )
+
+        // then
+        result.task(":buildChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "No projects have changed - nothing to build"
+    }
+
+    test("buildChangedProjectsFromRef succeeds without running printChangedProjectsFromRef") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        project.appendToFile(Files.MODULE1_SOURCE, "\n// Changed")
+        project.commitAll("Change module1")
+
+        // when
+        val result = project.runTaskWithProperties(
+            "buildChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then: buildChangedProjectsFromRef runs independently
+        result.task(":buildChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChangedProjectsFromRef") shouldBe null
+    }
+})

--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/PrintChangedProjectsFromRefFunctionalTest.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/PrintChangedProjectsFromRefFunctionalTest.kt
@@ -1,0 +1,225 @@
+package io.github.doughawley.monorepobuild.functional
+
+import io.github.doughawley.monorepobuild.functional.StandardTestProject.Files
+import io.github.doughawley.monorepobuild.functional.StandardTestProject.Projects
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+
+/**
+ * Functional tests for the printChangedProjectsFromRef task.
+ */
+class PrintChangedProjectsFromRefFunctionalTest : FunSpec({
+    val testProjectListener = listener(TestProjectListener())
+
+    test("printChangedProjectsFromRef fails with helpful error when no commitRef provided") {
+        // given
+        val project = testProjectListener.createStandardProject()
+
+        // when: run without commitRef
+        val result = project.runTaskAndFail("printChangedProjectsFromRef")
+
+        // then: error message mentions how to supply commitRef
+        result.output shouldContain "commitRef"
+        result.output shouldContain "monorepoBuild.commitRef"
+    }
+
+    test("printChangedProjectsFromRef detects directly changed project using commit SHA") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        // Make a change to common-lib and commit
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Modified")
+        project.commitAll("Modify common-lib")
+
+        // when
+        val result = project.runTaskWithProperties(
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then
+        result.task(":printChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changed = result.extractChangedProjects()
+        changed shouldContain Projects.COMMON_LIB
+    }
+
+    test("printChangedProjectsFromRef detects transitive dependents") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Modified")
+        project.commitAll("Modify common-lib")
+
+        // when
+        val result = project.runTaskWithProperties(
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then: common-lib plus all projects that depend on it are affected
+        result.task(":printChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changed = result.extractChangedProjects()
+        changed shouldContainAll setOf(
+            Projects.COMMON_LIB,
+            Projects.MODULE1,
+            Projects.MODULE2,
+            Projects.APP1,
+            Projects.APP2
+        )
+    }
+
+    test("printChangedProjectsFromRef only shows projects changed since the given ref") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+
+        // Change common-lib and commit
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// First change")
+        project.commitAll("Modify common-lib")
+        val afterFirstChangeSha = project.getLastCommitSha()
+
+        // Change only module1 in a second commit
+        project.appendToFile(Files.MODULE1_SOURCE, "\n// Second change")
+        project.commitAll("Modify module1")
+
+        // when: compare against the SHA after the first change — only module1 changes are newer
+        val result = project.runTaskWithProperties(
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to afterFirstChangeSha)
+        )
+
+        // then: only module1 and its dependents (app1) are affected, not common-lib
+        result.task(":printChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changed = result.extractChangedProjects()
+        changed shouldContain Projects.MODULE1
+        changed shouldContain Projects.APP1
+        changed shouldNotContain Projects.COMMON_LIB
+    }
+
+    test("printChangedProjectsFromRef property overrides DSL commitRef value") {
+        // given: build file sets commitRef to an invalid value in DSL
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        // Rewrite the build file to add an invalid DSL commitRef
+        project.modifyFile(
+            "build.gradle.kts",
+            """
+            plugins {
+                id("io.github.doug-hawley.monorepo-build-plugin")
+            }
+
+            monorepoBuild {
+                baseBranch = "HEAD"
+                includeUntracked = true
+                commitRef = "this-ref-does-not-exist"
+            }
+
+            allprojects {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            """.trimIndent()
+        )
+        project.commitAll("Add invalid DSL commitRef")
+
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Modified")
+        project.commitAll("Modify common-lib")
+
+        // when: valid SHA passed via property overrides the invalid DSL value
+        val result = project.runTaskWithProperties(
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then: property wins and task succeeds, detecting changes
+        result.task(":printChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changed = result.extractChangedProjects()
+        changed shouldContain Projects.COMMON_LIB
+    }
+
+    test("printChangedProjectsFromRef does not pick up untracked or staged-only changes") {
+        // given: two-dot diff skips working-tree and staged files
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        val initialSha = project.getLastCommitSha()
+
+        // Stage a change but do not commit
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Staged but not committed")
+        project.stageFile(Files.COMMON_LIB_SOURCE)
+
+        // Create an untracked file
+        project.createNewFile(
+            "common-lib/src/main/kotlin/com/example/Untracked.kt",
+            "class Untracked"
+        )
+
+        // when
+        val result = project.runTaskWithProperties(
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to initialSha)
+        )
+
+        // then: no projects reported as changed (staged/untracked changes are invisible to two-dot diff)
+        result.task(":printChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "No projects have changed"
+    }
+
+    test("printChangedProjectsFromRef fails with helpful error when commitRef does not exist") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+
+        // when: pass a SHA that does not exist
+        val result = project.runTaskWithPropertiesAndFail(
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+        )
+
+        // then
+        result.output shouldContain "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        result.output shouldContain "does not exist"
+    }
+
+    test("printChangedProjectsFromRef fails when both branch-mode and ref-mode tasks are invoked together") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+
+        // when
+        val result = project.runTaskWithPropertiesAndFail(
+            "printChangedProjectsFromBranch",
+            "printChangedProjectsFromRef",
+            properties = mapOf("monorepoBuild.commitRef" to "HEAD")
+        )
+
+        // then
+        result.output shouldContain "branch-mode"
+        result.output shouldContain "ref-mode"
+    }
+})


### PR DESCRIPTION
## Summary

Implements issue #42 — commit-ref based change detection tasks for CI systems that compare against a specific commit SHA or tag rather than a branch name.

- Adds `commitRef` DSL property to `monorepoBuild { }` (also accepts `-PmonorepoBuild.commitRef=<sha>` at runtime)
- New `printChangedProjectsFromRef` task: prints changed projects since a specific commit ref using two-dot diff
- New `buildChangedProjectsFromRef` task: builds only the projects affected since the given ref
- `resolveMode()` in the plugin inspects the requested task names and picks branch-mode vs ref-mode automatically; mixing the two modes in one invocation fails fast with a descriptive error
- Runtime property (`-PmonorepoBuild.commitRef`) takes precedence over the DSL value
- Two-dot diff (`git diff <ref> HEAD`) intentionally skips working-tree, staged, and untracked changes — appropriate for clean CI workspaces

## Test plan

- [ ] `./gradlew :monorepo-build-plugin:unitTest` — all existing unit tests pass
- [ ] `./gradlew :monorepo-build-plugin:functionalTest --tests "*.PrintChangedProjectsFromRefFunctionalTest"` — 8 new tests: missing ref error, direct detection, transitive dependents, scoped-since-ref, property-overrides-DSL, staged/untracked invisibility, invalid ref error, mixed-mode rejection
- [ ] `./gradlew :monorepo-build-plugin:functionalTest --tests "*.BuildChangedProjectsFromRefFunctionalTest"` — 5 new tests: missing ref error, direct build, transitive build, no-changes, independence from print task
- [ ] `./gradlew :monorepo-build-plugin:check` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)