### PR TITLE
refactor: consolidate all plugin tasks into a single "monorepo" task group

### DIFF
--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPlugin.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPlugin.kt
@@ -20,6 +20,7 @@ class MonorepoBuildPlugin @Inject constructor(
     private companion object {
         val REF_TASKS = setOf("printChangedProjectsFromRef", "buildChangedProjectsFromRef", "writeChangedProjectsFromRef")
         val BRANCH_TASKS = setOf("printChangedProjectsFromBranch", "buildChangedProjectsFromBranch")
+        const val TASK_GROUP = "monorepo"
     }
 
     override fun apply(project: Project) {
@@ -95,7 +96,7 @@ class MonorepoBuildPlugin @Inject constructor(
 
         // Register the printChangedProjectsFromBranch task
         project.tasks.register("printChangedProjectsFromBranch", PrintChangedProjectsTask::class.java).configure {
-            group = "verification"
+            group = TASK_GROUP
             description = "Detects which projects have changed based on git history"
         }
 
@@ -103,7 +104,7 @@ class MonorepoBuildPlugin @Inject constructor(
         // Actual dependsOn wiring for affected project build tasks is added dynamically
         // in the projectsEvaluated hook above, after changed projects are known.
         project.tasks.register("buildChangedProjectsFromBranch").configure {
-            group = "build"
+            group = TASK_GROUP
             description = "Builds only the projects that have been affected by changes"
             doLast {
                 val extension = project.rootProject.extensions.getByType(MonorepoBuildExtension::class.java)
@@ -128,7 +129,7 @@ class MonorepoBuildPlugin @Inject constructor(
 
         // Register the printChangedProjectsFromRef task
         project.tasks.register("printChangedProjectsFromRef", PrintChangedProjectsFromRefTask::class.java).configure {
-            group = "verification"
+            group = TASK_GROUP
             description = "Detects which projects changed since a specific commit ref"
         }
 
@@ -136,7 +137,7 @@ class MonorepoBuildPlugin @Inject constructor(
         // Actual dependsOn wiring for affected project build tasks is added dynamically
         // in the projectsEvaluated hook above, after changed projects are known.
         project.tasks.register("buildChangedProjectsFromRef").configure {
-            group = "build"
+            group = TASK_GROUP
             description = "Builds only the projects affected by changes since a specific commit ref"
             doLast {
                 val extension = project.rootProject.extensions.getByType(MonorepoBuildExtension::class.java)
@@ -164,7 +165,7 @@ class MonorepoBuildPlugin @Inject constructor(
         // Output file defaults to build/monorepo/changed-projects.txt but can be overridden
         // via -PmonorepoBuild.outputFile=<path> at runtime or by configuring the task directly.
         project.tasks.register("writeChangedProjectsFromRef", WriteChangedProjectsFromRefTask::class.java).configure {
-            group = "verification"
+            group = TASK_GROUP
             description = "Writes changed projects since a specific commit ref to a file for CI/CD pipeline consumption"
             val customPath = project.findProperty("monorepoBuild.outputFile") as? String
             if (customPath != null) {

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/BuildChangedProjectsTaskTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/BuildChangedProjectsTaskTest.kt
@@ -17,7 +17,7 @@ class BuildChangedProjectsTaskTest : FunSpec({
         // then
         val task = project.tasks.findByName("buildChangedProjectsFromBranch")
         task shouldNotBe null
-        task?.group shouldBe "build"
+        task?.group shouldBe "monorepo"
         task?.description shouldBe "Builds only the projects that have been affected by changes"
     }
 })

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPluginTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/MonorepoBuildPluginTest.kt
@@ -75,7 +75,7 @@ class MonorepoBuildPluginTest : FunSpec({
 
         // then
         task shouldNotBe null
-        task!!.group shouldBe "verification"
+        task!!.group shouldBe "monorepo"
         task.description shouldBe "Detects which projects have changed based on git history"
     }
 


### PR DESCRIPTION
## Summary

Moves all five plugin tasks out of the generic `verification` and `build` groups into a dedicated `monorepo` group, making the full plugin surface area immediately discoverable in any project.

Before:
```
Verification tasks
------------------
printChangedProjectsFromBranch
printChangedProjectsFromRef
writeChangedProjectsFromRef

Build tasks
-----------
buildChangedProjectsFromBranch
buildChangedProjectsFromRef
```

After:
```
Monorepo tasks
--------------
buildChangedProjectsFromBranch
buildChangedProjectsFromRef
printChangedProjectsFromBranch
printChangedProjectsFromRef
writeChangedProjectsFromRef
```

Users can now run `./gradlew tasks --group monorepo` to see exactly what the plugin provides.

## Changes

- Added `TASK_GROUP = "monorepo"` constant to the plugin companion object
- Applied it to all five task registrations
- Updated two unit tests that were asserting the old group names

## Test plan

- [ ] `./gradlew :monorepo-build-plugin:check` — all tests pass
- [ ] `./gradlew tasks --group monorepo` in a project using the plugin shows all five tasks together

🤖 Generated with [Claude Code](https://claude.com/claude-code)