### PR TITLE
refactor: extract ChangedProjectsPrinter to eliminate duplicated output logic

### DIFF
--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinter.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinter.kt
@@ -1,0 +1,93 @@
+package io.github.doughawley.monorepobuild
+
+import io.github.doughawley.monorepobuild.domain.ProjectMetadata
+import org.gradle.api.Project
+
+/**
+ * Formats the changed-projects report as a string.
+ *
+ * Responsible solely for formatting; callers supply the header and the three
+ * data values needed to render the report, and decide how to output the result.
+ */
+class ChangedProjectsPrinter(private val rootProject: Project) {
+
+    /**
+     * Builds the changed-projects report string.
+     *
+     * @param header The first line of the report (e.g. "Changed projects:" or "Changed projects (since abc123):")
+     * @param allAffectedProjects All project paths affected by the change (directly or transitively)
+     * @param changedFilesMap Map of project path to the files that changed directly in that project
+     * @param metadataMap Map of project path to its full metadata (used to resolve transitive "via" annotations)
+     * @return The formatted report string ready to be passed to a logger
+     */
+    fun buildReport(
+        header: String,
+        allAffectedProjects: Set<String>,
+        changedFilesMap: Map<String, List<String>>,
+        metadataMap: Map<String, ProjectMetadata>
+    ): String {
+        if (allAffectedProjects.isEmpty()) {
+            return "No projects have changed."
+        }
+
+        val directlyChanged = changedFilesMap.keys
+            .filter { it in allAffectedProjects }
+            .sorted()
+
+        val transitivelyAffected = allAffectedProjects
+            .filter { it !in changedFilesMap.keys }
+            .sorted()
+
+        val sb = StringBuilder()
+        sb.appendLine(header)
+
+        directlyChanged.forEach { projectPath ->
+            sb.appendLine()
+            sb.appendLine("  $projectPath")
+            val files = buildDisplayFiles(projectPath, changedFilesMap)
+            files.take(FILE_DISPLAY_LIMIT).forEach { sb.appendLine("    - $it") }
+            if (files.size > FILE_DISPLAY_LIMIT) {
+                sb.appendLine("    ... and ${files.size - FILE_DISPLAY_LIMIT} more")
+            }
+        }
+
+        if (transitivelyAffected.isNotEmpty()) {
+            sb.appendLine()
+            val maxPathLen = transitivelyAffected.maxOf { it.length }
+            transitivelyAffected.forEach { projectPath ->
+                val via = metadataMap[projectPath]
+                    ?.dependencies
+                    ?.filter { it.hasChanges() }
+                    ?.map { it.fullyQualifiedName }
+                    ?.sorted()
+                    ?.joinToString(", ")
+                    .orEmpty()
+                val annotation = if (via.isNotEmpty()) "  (affected via $via)" else ""
+                sb.appendLine("  ${projectPath.padEnd(maxPathLen)}$annotation")
+            }
+        }
+
+        return sb.toString().trimEnd()
+    }
+
+    private fun buildDisplayFiles(projectPath: String, changedFilesMap: Map<String, List<String>>): List<String> {
+        val files = changedFilesMap[projectPath].orEmpty()
+        val projectDir = rootProject.findProject(projectPath)
+            ?.projectDir
+            ?.relativeTo(rootProject.rootDir)
+            ?.path
+            ?.replace('\\', '/')
+            .orEmpty()
+        return files.map { file ->
+            if (projectDir.isNotEmpty() && file.startsWith("$projectDir/")) {
+                file.removePrefix("$projectDir/")
+            } else {
+                file
+            }
+        }.sorted()
+    }
+
+    companion object {
+        const val FILE_DISPLAY_LIMIT = 50
+    }
+}

--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsFromRefTask.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsFromRefTask.kt
@@ -1,5 +1,6 @@
 package io.github.doughawley.monorepobuild.task
 
+import io.github.doughawley.monorepobuild.ChangedProjectsPrinter
 import io.github.doughawley.monorepobuild.MonorepoBuildExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -12,7 +13,7 @@ import org.gradle.api.tasks.TaskAction
  *   - Directly changed projects are listed with their changed files (relative to the project directory).
  *   - Transitively affected projects are listed with an "(affected via ...)" annotation naming
  *     the direct dependencies that carry the change.
- *   - File lists are capped at FILE_DISPLAY_LIMIT entries.
+ *   - File lists are capped at ChangedProjectsPrinter.FILE_DISPLAY_LIMIT entries.
  */
 abstract class PrintChangedProjectsFromRefTask : DefaultTask() {
 
@@ -30,71 +31,11 @@ abstract class PrintChangedProjectsFromRefTask : DefaultTask() {
         }
 
         val resolvedRef = extension.commitRef
-        val allAffected = extension.allAffectedProjects
-
-        if (allAffected.isEmpty()) {
-            logger.lifecycle("No projects have changed.")
-            return
-        }
-
-        val directlyChanged = extension.changedFilesMap.keys
-            .filter { it in allAffected }
-            .sorted()
-
-        val transitivelyAffected = allAffected
-            .filter { it !in extension.changedFilesMap.keys }
-            .sorted()
-
-        val sb = StringBuilder()
-        sb.appendLine("Changed projects (since $resolvedRef):")
-
-        directlyChanged.forEach { projectPath ->
-            sb.appendLine()
-            sb.appendLine("  $projectPath")
-            val files = buildDisplayFiles(projectPath, extension.changedFilesMap)
-            files.take(FILE_DISPLAY_LIMIT).forEach { sb.appendLine("    - $it") }
-            if (files.size > FILE_DISPLAY_LIMIT) {
-                sb.appendLine("    ... and ${files.size - FILE_DISPLAY_LIMIT} more")
-            }
-        }
-
-        if (transitivelyAffected.isNotEmpty()) {
-            sb.appendLine()
-            val maxPathLen = transitivelyAffected.maxOf { it.length }
-            transitivelyAffected.forEach { projectPath ->
-                val via = extension.metadataMap[projectPath]
-                    ?.dependencies
-                    ?.filter { it.hasChanges() }
-                    ?.map { it.fullyQualifiedName }
-                    ?.sorted()
-                    ?.joinToString(", ")
-                    .orEmpty()
-                val annotation = if (via.isNotEmpty()) "  (affected via $via)" else ""
-                sb.appendLine("  ${projectPath.padEnd(maxPathLen)}$annotation")
-            }
-        }
-
-        logger.lifecycle(sb.toString().trimEnd())
-    }
-
-    private fun buildDisplayFiles(projectPath: String, changedFilesMap: Map<String, List<String>>): List<String> {
-        val files = changedFilesMap[projectPath].orEmpty()
-        val projectDir = project.rootProject.findProject(projectPath)
-            ?.projectDir
-            ?.relativeTo(project.rootProject.rootDir)
-            ?.path
-            ?.replace('\\', '/')
-            .orEmpty()
-        return files.map { file ->
-            if (projectDir.isNotEmpty() && file.startsWith("$projectDir/")) {
-                file.removePrefix("$projectDir/")
-            } else {
-                file
-            }
-        }.sorted()
-    }
-
-    companion object {
-        internal const val FILE_DISPLAY_LIMIT = 50
+        logger.lifecycle(ChangedProjectsPrinter(project.rootProject).buildReport(
+            header = "Changed projects (since $resolvedRef):",
+            allAffectedProjects = extension.allAffectedProjects,
+            changedFilesMap = extension.changedFilesMap,
+            metadataMap = extension.metadataMap
+        ))
     }
 }

--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsTask.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsTask.kt
@@ -1,5 +1,6 @@
 package io.github.doughawley.monorepobuild.task
 
+import io.github.doughawley.monorepobuild.ChangedProjectsPrinter
 import io.github.doughawley.monorepobuild.MonorepoBuildExtension
 import io.github.doughawley.monorepobuild.MonorepoBuildPlugin
 import org.gradle.api.DefaultTask
@@ -12,7 +13,7 @@ import org.gradle.api.tasks.TaskAction
  *   - Directly changed projects are listed with their changed files (relative to the project directory).
  *   - Transitively affected projects are listed with an "(affected via ...)" annotation naming
  *     the direct dependencies that carry the change.
- *   - File lists are capped at FILE_DISPLAY_LIMIT entries.
+ *   - File lists are capped at ChangedProjectsPrinter.FILE_DISPLAY_LIMIT entries.
  */
 abstract class PrintChangedProjectsTask : DefaultTask() {
 
@@ -36,71 +37,11 @@ abstract class PrintChangedProjectsTask : DefaultTask() {
             }
         }
 
-        val allAffected = extension.allAffectedProjects
-
-        if (allAffected.isEmpty()) {
-            logger.lifecycle("No projects have changed.")
-            return
-        }
-
-        val directlyChanged = extension.changedFilesMap.keys
-            .filter { it in allAffected }
-            .sorted()
-
-        val transitivelyAffected = allAffected
-            .filter { it !in extension.changedFilesMap.keys }
-            .sorted()
-
-        val sb = StringBuilder()
-        sb.appendLine("Changed projects:")
-
-        directlyChanged.forEach { projectPath ->
-            sb.appendLine()
-            sb.appendLine("  $projectPath")
-            val files = buildDisplayFiles(projectPath, extension.changedFilesMap)
-            files.take(FILE_DISPLAY_LIMIT).forEach { sb.appendLine("    - $it") }
-            if (files.size > FILE_DISPLAY_LIMIT) {
-                sb.appendLine("    ... and ${files.size - FILE_DISPLAY_LIMIT} more")
-            }
-        }
-
-        if (transitivelyAffected.isNotEmpty()) {
-            sb.appendLine()
-            val maxPathLen = transitivelyAffected.maxOf { it.length }
-            transitivelyAffected.forEach { projectPath ->
-                val via = extension.metadataMap[projectPath]
-                    ?.dependencies
-                    ?.filter { it.hasChanges() }
-                    ?.map { it.fullyQualifiedName }
-                    ?.sorted()
-                    ?.joinToString(", ")
-                    .orEmpty()
-                val annotation = if (via.isNotEmpty()) "  (affected via $via)" else ""
-                sb.appendLine("  ${projectPath.padEnd(maxPathLen)}$annotation")
-            }
-        }
-
-        logger.lifecycle(sb.toString().trimEnd())
-    }
-
-    private fun buildDisplayFiles(projectPath: String, changedFilesMap: Map<String, List<String>>): List<String> {
-        val files = changedFilesMap[projectPath].orEmpty()
-        val projectDir = project.rootProject.findProject(projectPath)
-            ?.projectDir
-            ?.relativeTo(project.rootProject.rootDir)
-            ?.path
-            ?.replace('\\', '/')
-            .orEmpty()
-        return files.map { file ->
-            if (projectDir.isNotEmpty() && file.startsWith("$projectDir/")) {
-                file.removePrefix("$projectDir/")
-            } else {
-                file
-            }
-        }.sorted()
-    }
-
-    companion object {
-        internal const val FILE_DISPLAY_LIMIT = 50
+        logger.lifecycle(ChangedProjectsPrinter(project.rootProject).buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = extension.allAffectedProjects,
+            changedFilesMap = extension.changedFilesMap,
+            metadataMap = extension.metadataMap
+        ))
     }
 }

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinterTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinterTest.kt
@@ -1,0 +1,163 @@
+package io.github.doughawley.monorepobuild
+
+import io.github.doughawley.monorepobuild.domain.ProjectMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.gradle.testfixtures.ProjectBuilder
+
+class ChangedProjectsPrinterTest : FunSpec({
+
+    test("returns no-changes message when no projects are affected") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = emptySet(),
+            changedFilesMap = emptyMap(),
+            metadataMap = emptyMap()
+        )
+
+        // then
+        result shouldBe "No projects have changed."
+    }
+
+    test("includes custom header in the output") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects (since abc123):",
+            allAffectedProjects = setOf(":api"),
+            changedFilesMap = mapOf(":api" to listOf("api/src/main/kotlin/Api.kt")),
+            metadataMap = mapOf(":api" to ProjectMetadata("api", ":api", changedFiles = listOf("api/src/main/kotlin/Api.kt")))
+        )
+
+        // then
+        result shouldContain "Changed projects (since abc123):"
+    }
+
+    test("lists directly changed project and its files") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = setOf(":api"),
+            changedFilesMap = mapOf(":api" to listOf("api/src/main/kotlin/Api.kt")),
+            metadataMap = mapOf(":api" to ProjectMetadata("api", ":api", changedFiles = listOf("api/src/main/kotlin/Api.kt")))
+        )
+
+        // then
+        result shouldContain ":api"
+        result shouldContain "src/main/kotlin/Api.kt"
+    }
+
+    test("strips project directory prefix from file paths") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = setOf(":api"),
+            changedFilesMap = mapOf(":api" to listOf("api/src/main/kotlin/Api.kt")),
+            metadataMap = mapOf(":api" to ProjectMetadata("api", ":api", changedFiles = listOf("api/src/main/kotlin/Api.kt")))
+        )
+
+        // then — "api/" prefix is stripped because the project dir is resolved relative to rootDir
+        result shouldNotContain "api/src/main/kotlin/Api.kt"
+        result shouldContain "src/main/kotlin/Api.kt"
+    }
+
+    test("lists transitively affected project with via annotation") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
+        ProjectBuilder.builder().withParent(rootProject).withName("app").build()
+
+        val apiMetadata = ProjectMetadata(
+            name = "api",
+            fullyQualifiedName = ":api",
+            changedFiles = listOf("api/src/main/kotlin/Api.kt")
+        )
+        val appMetadata = ProjectMetadata(
+            name = "app",
+            fullyQualifiedName = ":app",
+            dependencies = listOf(apiMetadata)
+        )
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = setOf(":api", ":app"),
+            changedFilesMap = mapOf(":api" to listOf("api/src/main/kotlin/Api.kt")),
+            metadataMap = mapOf(":api" to apiMetadata, ":app" to appMetadata)
+        )
+
+        // then
+        result shouldContain ":api"
+        result shouldContain ":app"
+        result shouldContain "affected via :api"
+    }
+
+    test("truncates file list when exceeding FILE_DISPLAY_LIMIT") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
+        val manyFiles = (1..ChangedProjectsPrinter.FILE_DISPLAY_LIMIT + 5)
+            .map { "api/src/main/kotlin/File$it.kt" }
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = setOf(":api"),
+            changedFilesMap = mapOf(":api" to manyFiles),
+            metadataMap = mapOf(":api" to ProjectMetadata("api", ":api", changedFiles = manyFiles))
+        )
+
+        // then
+        result shouldContain "... and 5 more"
+    }
+
+    test("multiple directly changed projects are listed sorted") {
+        // given
+        val rootProject = ProjectBuilder.builder().build()
+        ProjectBuilder.builder().withParent(rootProject).withName("beta").build()
+        ProjectBuilder.builder().withParent(rootProject).withName("alpha").build()
+        val printer = ChangedProjectsPrinter(rootProject)
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            allAffectedProjects = setOf(":alpha", ":beta"),
+            changedFilesMap = mapOf(
+                ":beta" to listOf("beta/src/main/kotlin/Beta.kt"),
+                ":alpha" to listOf("alpha/src/main/kotlin/Alpha.kt")
+            ),
+            metadataMap = mapOf(
+                ":alpha" to ProjectMetadata("alpha", ":alpha", changedFiles = listOf("alpha/src/main/kotlin/Alpha.kt")),
+                ":beta" to ProjectMetadata("beta", ":beta", changedFiles = listOf("beta/src/main/kotlin/Beta.kt"))
+            )
+        )
+
+        // then
+        val alphaIndex = result.indexOf(":alpha")
+        val betaIndex = result.indexOf(":beta")
+        (alphaIndex < betaIndex) shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

- Extract shared output rendering from `PrintChangedProjectsTask` and `PrintChangedProjectsFromRefTask` into a new `ChangedProjectsPrinter` class
- `ChangedProjectsPrinter.buildReport()` takes only the three data values it needs (`allAffectedProjects`, `changedFilesMap`, `metadataMap`) and returns a formatted `String` — no dependency on `MonorepoBuildExtension` or a logger
- Both tasks now delegate to the printer, reduced to their distinct concerns: the pre-check and the header string
- Add `ChangedProjectsPrinterTest` with 6 unit tests covering the no-changes case, header, file path stripping, transitive annotation, truncation, and sort order

## Test plan

- [ ] `./gradlew :monorepo-build-plugin:unitTest` — all unit tests pass including the new `ChangedProjectsPrinterTest`
- [ ] `./gradlew :monorepo-build-plugin:functionalTest` — existing functional tests for both print tasks pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)