### PR TITLE
perf: remove isolated GRADLE_USER_HOME to allow daemon reuse across functional tests

### DIFF
--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/TestProjectBuilder.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/TestProjectBuilder.kt
@@ -3,7 +3,6 @@ package io.github.doughawley.monorepobuild.functional
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
-import kotlin.io.path.createTempDirectory
 
 /**
  * Builder for creating test Gradle projects for functional testing.
@@ -178,8 +177,6 @@ class TestProject(
     private val remoteDir: File? = null
 ) {
 
-    val gradleUserHome: File = createTempDirectory("gradle-user-home-").toFile()
-
     fun initGit() {
         if (useRemote && remoteDir != null) {
             // Create a bare repository to act as origin
@@ -274,7 +271,6 @@ class TestProject(
 
     private fun gradleRunner(): GradleRunner {
         val env = HashMap(System.getenv())
-        env["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
         // Strip env vars that trigger Develocity auto-injection via gradle/actions/setup-gradle.
         // The injected init script interferes with projectsEvaluated task registration in CI.
         env.keys.removeIf { it.startsWith("DEVELOCITY_") || it.startsWith("GRADLE_BUILD_ACTION_") }

--- a/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/TestProjectListener.kt
+++ b/monorepo-build-plugin/src/test/functional/kotlin/io/github/doughawley/monorepobuild/functional/TestProjectListener.kt
@@ -65,7 +65,6 @@ class TestProjectListener : TestListener {
     }
 
     override suspend fun afterEach(testCase: TestCase, result: TestResult) {
-        currentTestProject?.gradleUserHome?.deleteRecursively()
         currentTestProject = null
         currentTestDir?.let { dir ->
             if (dir.exists()) {


### PR DESCRIPTION
## Summary

- Removes the per-test isolated `GRADLE_USER_HOME` from `TestProject`, which was preventing Gradle daemon reuse between functional tests
- The CI issue it was originally meant to fix (Develocity auto-injection via `gradle/actions/setup-gradle`) is already handled by stripping `DEVELOCITY_*` and `GRADLE_BUILD_ACTION_*` env vars
- Each test still gets its own isolated project directory — only the Gradle user home is now shared

## Test plan

- [x] All 52 functional tests pass (`BUILD SUCCESSFUL`)
- [x] Observed wall time of ~3m 22s (down from estimated 7–13 min before daemon reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)