### PR TITLE
fix: use component-scoped outputs for release-please monorepo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs['monorepo-build-plugin--release_created'] }}
+      tag_name: ${{ steps.release.outputs['monorepo-build-plugin--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Summary

- The `publish` job was always skipped because `release_created` evaluated to false
- With a monorepo `release-please-config.json`, `release-please-action@v4` emits component-namespaced outputs (`monorepo-build-plugin--release_created`, `monorepo-build-plugin--tag_name`) rather than the bare keys
- Updated the job `outputs` block to reference the correct component-scoped keys

## Test plan

- [ ] Merge a release-please PR and confirm the `publish` job runs after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)