### PR TITLE
feat: remove file list from print task output

### DIFF
--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinter.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinter.kt
@@ -1,7 +1,6 @@
 package io.github.doughawley.monorepobuild
 
 import io.github.doughawley.monorepobuild.domain.MonorepoProjects
-import org.gradle.api.Project
 
 /**
  * Formats the changed-projects report as a string.
@@ -9,7 +8,7 @@ import org.gradle.api.Project
  * Responsible solely for formatting; callers supply the header and the domain
  * object, and decide how to output the result.
  */
-class ChangedProjectsPrinter(private val rootProject: Project) {
+class ChangedProjectsPrinter {
 
     /**
      * Builds the changed-projects report string.
@@ -38,16 +37,9 @@ class ChangedProjectsPrinter(private val rootProject: Project) {
 
         val sb = StringBuilder()
         sb.appendLine(header)
-
+        sb.appendLine()
         directlyChanged.forEach { projectPath ->
-            val project = monorepoProjects.projects.find { it.fullyQualifiedName == projectPath }
-            val files = buildDisplayFiles(projectPath, project?.changedFiles.orEmpty())
-            sb.appendLine()
             sb.appendLine("  $projectPath")
-            files.take(FILE_DISPLAY_LIMIT).forEach { sb.appendLine("    - $it") }
-            if (files.size > FILE_DISPLAY_LIMIT) {
-                sb.appendLine("    ... and ${files.size - FILE_DISPLAY_LIMIT} more")
-            }
         }
 
         if (transitivelyAffected.isNotEmpty()) {
@@ -67,25 +59,5 @@ class ChangedProjectsPrinter(private val rootProject: Project) {
         }
 
         return sb.toString().trimEnd()
-    }
-
-    private fun buildDisplayFiles(projectPath: String, files: List<String>): List<String> {
-        val projectDir = rootProject.findProject(projectPath)
-            ?.projectDir
-            ?.relativeTo(rootProject.rootDir)
-            ?.path
-            ?.replace('\\', '/')
-            .orEmpty()
-        return files.map { file ->
-            if (projectDir.isNotEmpty() && file.startsWith("$projectDir/")) {
-                file.removePrefix("$projectDir/")
-            } else {
-                file
-            }
-        }.sorted()
-    }
-
-    companion object {
-        const val FILE_DISPLAY_LIMIT = 50
     }
 }

--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsFromRefTask.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsFromRefTask.kt
@@ -10,10 +10,9 @@ import org.gradle.api.tasks.TaskAction
  * Task that prints which projects have changed since a specific commit ref.
  *
  * Output format:
- *   - Directly changed projects are listed with their changed files (relative to the project directory).
+ *   - Directly changed projects are listed by path.
  *   - Transitively affected projects are listed with an "(affected via ...)" annotation naming
  *     the direct dependencies that carry the change.
- *   - File lists are capped at ChangedProjectsPrinter.FILE_DISPLAY_LIMIT entries.
  */
 abstract class PrintChangedProjectsFromRefTask : DefaultTask() {
 
@@ -31,7 +30,7 @@ abstract class PrintChangedProjectsFromRefTask : DefaultTask() {
         }
 
         val resolvedRef = extension.commitRef
-        logger.lifecycle(ChangedProjectsPrinter(project.rootProject).buildReport(
+        logger.lifecycle(ChangedProjectsPrinter().buildReport(
             header = "Changed projects (since $resolvedRef):",
             monorepoProjects = extension.monorepoProjects
         ))

--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsTask.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/task/PrintChangedProjectsTask.kt
@@ -10,10 +10,9 @@ import org.gradle.api.tasks.TaskAction
  * Task that prints which projects have changed based on git history and dependency analysis.
  *
  * Output format:
- *   - Directly changed projects are listed with their changed files (relative to the project directory).
+ *   - Directly changed projects are listed by path.
  *   - Transitively affected projects are listed with an "(affected via ...)" annotation naming
  *     the direct dependencies that carry the change.
- *   - File lists are capped at ChangedProjectsPrinter.FILE_DISPLAY_LIMIT entries.
  */
 abstract class PrintChangedProjectsTask : DefaultTask() {
 
@@ -37,7 +36,7 @@ abstract class PrintChangedProjectsTask : DefaultTask() {
             }
         }
 
-        logger.lifecycle(ChangedProjectsPrinter(project.rootProject).buildReport(
+        logger.lifecycle(ChangedProjectsPrinter().buildReport(
             header = "Changed projects:",
             monorepoProjects = extension.monorepoProjects
         ))

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinterTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinterTest.kt
@@ -5,15 +5,12 @@ import io.github.doughawley.monorepobuild.domain.ProjectMetadata
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
-import org.gradle.testfixtures.ProjectBuilder
 
 class ChangedProjectsPrinterTest : FunSpec({
 
     test("returns no-changes message when no projects are affected") {
         // given
-        val rootProject = ProjectBuilder.builder().build()
-        val printer = ChangedProjectsPrinter(rootProject)
+        val printer = ChangedProjectsPrinter()
 
         // when
         val result = printer.buildReport(
@@ -27,9 +24,7 @@ class ChangedProjectsPrinterTest : FunSpec({
 
     test("includes custom header in the output") {
         // given
-        val rootProject = ProjectBuilder.builder().build()
-        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
-        val printer = ChangedProjectsPrinter(rootProject)
+        val printer = ChangedProjectsPrinter()
         val apiMetadata = ProjectMetadata("api", ":api", changedFiles = listOf("api/src/main/kotlin/Api.kt"))
 
         // when
@@ -42,11 +37,9 @@ class ChangedProjectsPrinterTest : FunSpec({
         result shouldContain "Changed projects (since abc123):"
     }
 
-    test("lists directly changed project and its files") {
+    test("lists directly changed project path") {
         // given
-        val rootProject = ProjectBuilder.builder().build()
-        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
-        val printer = ChangedProjectsPrinter(rootProject)
+        val printer = ChangedProjectsPrinter()
         val apiMetadata = ProjectMetadata("api", ":api", changedFiles = listOf("api/src/main/kotlin/Api.kt"))
 
         // when
@@ -57,33 +50,10 @@ class ChangedProjectsPrinterTest : FunSpec({
 
         // then
         result shouldContain ":api"
-        result shouldContain "src/main/kotlin/Api.kt"
-    }
-
-    test("strips project directory prefix from file paths") {
-        // given
-        val rootProject = ProjectBuilder.builder().build()
-        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
-        val printer = ChangedProjectsPrinter(rootProject)
-        val apiMetadata = ProjectMetadata("api", ":api", changedFiles = listOf("api/src/main/kotlin/Api.kt"))
-
-        // when
-        val result = printer.buildReport(
-            header = "Changed projects:",
-            monorepoProjects = MonorepoProjects(listOf(apiMetadata))
-        )
-
-        // then — "api/" prefix is stripped because the project dir is resolved relative to rootDir
-        result shouldNotContain "api/src/main/kotlin/Api.kt"
-        result shouldContain "src/main/kotlin/Api.kt"
     }
 
     test("lists transitively affected project with via annotation") {
         // given
-        val rootProject = ProjectBuilder.builder().build()
-        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
-        ProjectBuilder.builder().withParent(rootProject).withName("app").build()
-
         val apiMetadata = ProjectMetadata(
             name = "api",
             fullyQualifiedName = ":api",
@@ -94,7 +64,7 @@ class ChangedProjectsPrinterTest : FunSpec({
             fullyQualifiedName = ":app",
             dependencies = listOf(apiMetadata)
         )
-        val printer = ChangedProjectsPrinter(rootProject)
+        val printer = ChangedProjectsPrinter()
 
         // when
         val result = printer.buildReport(
@@ -108,30 +78,9 @@ class ChangedProjectsPrinterTest : FunSpec({
         result shouldContain "affected via :api"
     }
 
-    test("truncates file list when exceeding FILE_DISPLAY_LIMIT") {
-        // given
-        val rootProject = ProjectBuilder.builder().build()
-        ProjectBuilder.builder().withParent(rootProject).withName("api").build()
-        val manyFiles = (1..ChangedProjectsPrinter.FILE_DISPLAY_LIMIT + 5)
-            .map { "api/src/main/kotlin/File$it.kt" }
-        val printer = ChangedProjectsPrinter(rootProject)
-
-        // when
-        val result = printer.buildReport(
-            header = "Changed projects:",
-            monorepoProjects = MonorepoProjects(listOf(ProjectMetadata("api", ":api", changedFiles = manyFiles)))
-        )
-
-        // then
-        result shouldContain "... and 5 more"
-    }
-
     test("multiple directly changed projects are listed sorted") {
         // given
-        val rootProject = ProjectBuilder.builder().build()
-        ProjectBuilder.builder().withParent(rootProject).withName("beta").build()
-        ProjectBuilder.builder().withParent(rootProject).withName("alpha").build()
-        val printer = ChangedProjectsPrinter(rootProject)
+        val printer = ChangedProjectsPrinter()
         val alphaMetadata = ProjectMetadata("alpha", ":alpha", changedFiles = listOf("alpha/src/main/kotlin/Alpha.kt"))
         val betaMetadata = ProjectMetadata("beta", ":beta", changedFiles = listOf("beta/src/main/kotlin/Beta.kt"))
 


### PR DESCRIPTION
## Summary

- File paths in the changed-projects report were too noisy to be useful in practice
- Directly changed projects are now listed by path only, consistent with the transitively-affected section
- Removes `buildDisplayFiles`, `FILE_DISPLAY_LIMIT`, and the `rootProject` constructor parameter from `ChangedProjectsPrinter` (no longer needed)

**Before:**
```
Changed projects:

  :module1
    - src/main/kotlin/Foo.kt
    - src/main/kotlin/Bar.kt

  :common-lib
    - src/main/kotlin/Api.kt
```

**After:**
```
Changed projects:

  :common-lib
  :module1

  :app1  (affected via :module1)
```

## Test plan

- [x] Unit tests updated and passing
- [ ] Run `printChangedProjects` or `printChangedProjectsFromRef` in a real project and confirm output is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)