### PR TITLE
build: prepare release-please for multi-plugin monorepo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['monorepo-build-plugin--release_created'] }}
-      tag_name: ${{ steps.release.outputs['monorepo-build-plugin--tag_name'] }}
+      release_created: ${{ steps.release.outputs['release_created'] }}
+      tag_name: ${{ steps.release.outputs['tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "monorepo-build-plugin": "0.3.1"
+  ".": "0.3.1"
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This dramatically reduces build times in CI/CD pipelines by avoiding unnecessary
 
 ```kotlin
 plugins {
-    id("io.github.doug-hawley.monorepo-build-plugin") version "0.2.0" // x-release-please-version
+    id("io.github.doug-hawley.monorepo-build-plugin") version "0.3.1" // x-release-please-version
 }
 ```
 

--- a/examples/access-changed-files.gradle.kts
+++ b/examples/access-changed-files.gradle.kts
@@ -2,7 +2,7 @@
 // Place this in your root build.gradle.kts
 
 plugins {
-    id("io.github.doug-hawley.monorepo-build-plugin") version "0.2.0" // x-release-please-version
+    id("io.github.doug-hawley.monorepo-build-plugin") version "0.3.1" // x-release-please-version
 }
 
 monorepoBuild {

--- a/monorepo-build-plugin/build.gradle.kts
+++ b/monorepo-build-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.doug-hawley"
-version = "0.2.0"
+version = "0.3.1" // x-release-please-version
 
 repositories {
     mavenCentral()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,8 @@
 {
   "release-type": "simple",
   "packages": {
-    "monorepo-build-plugin": {
-      "package-name": "monorepo-build-plugin",
+    ".": {
+      "package-name": "monorepo-gradle-plugins",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary

- Switches the release-please package key from `monorepo-build-plugin` to `"."` (repo root) so any commit can trigger a release and all plugins will always share the same version
- Fixes a version mismatch where source files had been manually reset to `0.2.0` while the manifest tracked `0.3.1`
- Updates workflow output key references to match the new root-package naming (drops the `monorepo-build-plugin--` prefix)

## When the second plugin is added

Two additional steps will be needed:
1. Add the new plugin's `build.gradle.kts` to `extra-files` in `release-please-config.json`
2. Add a `publishPlugins` call for it in the `publish` job in `release-please.yml`

## Test plan

- [ ] Verify release-please action parses config without errors on next push to main
- [ ] Confirm a release PR correctly bumps the version in both `build.gradle.kts` files (once second plugin exists)
- [ ] Confirm publish job triggers on release creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)