### PR TITLE
fix: display root project as ': (root)' instead of ':' in print output

### DIFF
--- a/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinter.kt
+++ b/monorepo-build-plugin/src/main/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinter.kt
@@ -39,25 +39,29 @@ class ChangedProjectsPrinter {
         sb.appendLine(header)
         sb.appendLine()
         directlyChanged.forEach { projectPath ->
-            sb.appendLine("  $projectPath")
+            sb.appendLine("  ${displayPath(projectPath)}")
         }
 
         if (transitivelyAffected.isNotEmpty()) {
             sb.appendLine()
-            val maxPathLen = transitivelyAffected.maxOf { it.length }
+            val maxPathLen = transitivelyAffected.maxOf { displayPath(it).length }
             transitivelyAffected.forEach { projectPath ->
                 val via = monorepoProjects.projects.find { it.fullyQualifiedName == projectPath }
                     ?.dependencies
                     ?.filter { it.hasChanges() }
-                    ?.map { it.fullyQualifiedName }
+                    ?.map { displayPath(it.fullyQualifiedName) }
                     ?.sorted()
                     ?.joinToString(", ")
                     .orEmpty()
                 val annotation = if (via.isNotEmpty()) "  (affected via $via)" else ""
-                sb.appendLine("  ${projectPath.padEnd(maxPathLen)}$annotation")
+                sb.appendLine("  ${displayPath(projectPath).padEnd(maxPathLen)}$annotation")
             }
         }
 
         return sb.toString().trimEnd()
+    }
+
+    private fun displayPath(path: String): String {
+        return if (path == ":") ": (root)" else path
     }
 }

--- a/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinterTest.kt
+++ b/monorepo-build-plugin/src/test/unit/kotlin/io/github/doughawley/monorepobuild/ChangedProjectsPrinterTest.kt
@@ -78,6 +78,21 @@ class ChangedProjectsPrinterTest : FunSpec({
         result shouldContain "affected via :api"
     }
 
+    test("displays root project as ': (root)' instead of ':'") {
+        // given
+        val printer = ChangedProjectsPrinter()
+        val rootMetadata = ProjectMetadata("my-project", ":", changedFiles = listOf("build.gradle.kts"))
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            monorepoProjects = MonorepoProjects(listOf(rootMetadata))
+        )
+
+        // then
+        result shouldContain ": (root)"
+    }
+
     test("multiple directly changed projects are listed sorted") {
         // given
         val printer = ChangedProjectsPrinter()


### PR DESCRIPTION
## Summary

- Fixes a bug where the root Gradle project (path `":"`) appeared as a bare `":"` as the first entry in the print output
- Adds a `displayPath` private helper in `ChangedProjectsPrinter` that renders `":"` as `": (root)"` for clarity
- Adds a unit test covering the root project display case

## Test plan

- [ ] Verify `ChangedProjectsPrinterTest` passes — all 6 tests including new root project case
- [ ] Manually confirm print output no longer shows bare `":"` when root project files have changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)