### PR TITLE
docs: update all references from old plugin IDs to monorepo-build-release-plugin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,10 +38,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Build plugin
-        run: ./gradlew :monorepo-build-plugin:build --no-daemon
+        run: ./gradlew :monorepo-build-release-plugin:build --no-daemon
 
       - name: Publish to Gradle Plugin Portal
-        run: ./gradlew :monorepo-build-plugin:publishPlugins --no-daemon
+        run: ./gradlew :monorepo-build-release-plugin:publishPlugins --no-daemon
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
@@ -50,4 +50,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-${{ needs.release-please.outputs.tag_name }}
-          path: monorepo-build-plugin/build/libs/*.jar
+          path: monorepo-build-release-plugin/build/libs/*.jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,23 +32,18 @@ cd monorepo-gradle-plugins
 
 ```
 monorepo-gradle-plugins/
-├── monorepo-build-plugin/
+├── monorepo-build-release-plugin/
 │   ├── src/
-│   │   ├── main/kotlin/io/github/doughawley/monorepobuild/
-│   │   │   ├── MonorepoBuildPlugin.kt
-│   │   │   ├── MonorepoBuildExtension.kt
-│   │   │   ├── PrintChangedProjectsTask.kt
-│   │   │   ├── GitChangedFilesDetector.kt
-│   │   │   ├── ProjectFileMapper.kt
-│   │   │   ├── domain/
-│   │   │   │   ├── ChangedProjects.kt
-│   │   │   │   └── ProjectMetadata.kt
-│   │   │   └── git/
-│   │   │       └── GitCommandExecutor.kt
+│   │   ├── main/kotlin/io/github/doughawley/
+│   │   │   ├── monorepo/MonorepoBuildReleasePlugin.kt   # plugin entry point
+│   │   │   ├── monorepobuild/                           # change detection
+│   │   │   └── monoreporelease/                         # versioned tagging
 │   │   └── test/
 │   │       ├── unit/kotlin/           # Unit tests
-│   │       └── functional/kotlin/     # Functional tests with Gradle TestKit
+│   │       ├── integration/kotlin/    # Integration tests (real git, no TestKit)
+│   │       └── functional/kotlin/    # Functional tests with Gradle TestKit
 │   └── build.gradle.kts
+├── monorepo-plugin-core/              # Shared git utilities
 ├── build.gradle.kts
 ├── settings.gradle.kts
 └── gradle.properties
@@ -71,13 +66,13 @@ The plugin consists of several key components:
 Build the plugin and run all tests:
 
 ```bash
-./gradlew :monorepo-build-plugin:build
+./gradlew :monorepo-build-release-plugin:build
 ```
 
 ### Quick Build (Skip Tests)
 
 ```bash
-./gradlew :monorepo-build-plugin:build -x test
+./gradlew :monorepo-build-release-plugin:build -x test
 ```
 
 ### Assemble Only
@@ -85,10 +80,10 @@ Build the plugin and run all tests:
 Create the JAR without running tests:
 
 ```bash
-./gradlew :monorepo-build-plugin:assemble
+./gradlew :monorepo-build-release-plugin:assemble
 ```
 
-The built plugin JAR will be in `monorepo-build-plugin/build/libs/monorepo-build-plugin-1.1.0.jar`.
+The built plugin JAR will be in `monorepo-build-release-plugin/build/libs/`.
 
 ## Running Tests
 
@@ -97,31 +92,32 @@ This project uses [Kotest](https://kotest.io/) for testing with separate unit an
 ### Run All Tests
 
 ```bash
-./gradlew :monorepo-build-plugin:check
+./gradlew :monorepo-build-release-plugin:check
 ```
 
 ### Run Unit Tests Only
 
 ```bash
-./gradlew :monorepo-build-plugin:unitTest
+./gradlew :monorepo-build-release-plugin:unitTest
 ```
 
 ### Run Functional Tests Only
 
 ```bash
-./gradlew :monorepo-build-plugin:functionalTest
+./gradlew :monorepo-build-release-plugin:functionalTest
 ```
 
 ### Run Tests with Logging
 
 ```bash
-./gradlew :monorepo-build-plugin:unitTest --info
+./gradlew :monorepo-build-release-plugin:unitTest --info
 ```
 
 ### Test Structure
 
-- **Unit Tests** (`monorepo-build-plugin/src/test/unit/kotlin/`) - Fast, isolated tests for individual components
-- **Functional Tests** (`monorepo-build-plugin/src/test/functional/kotlin/`) - End-to-end tests using Gradle TestKit
+- **Unit Tests** (`monorepo-build-release-plugin/src/test/unit/kotlin/`) - Fast, isolated tests for individual components
+- **Integration Tests** (`monorepo-build-release-plugin/src/test/integration/kotlin/`) - Tests against a real git backend without Gradle TestKit
+- **Functional Tests** (`monorepo-build-release-plugin/src/test/functional/kotlin/`) - End-to-end tests using Gradle TestKit
 
 For more information on testing, see:
 - [TEST_STRUCTURE.md](TEST_STRUCTURE.md)
@@ -226,12 +222,12 @@ For more details, see [RELEASE_PLEASE_GUIDE.md](RELEASE_PLEASE_GUIDE.md).
 
 1. **Run tests**: Ensure all tests pass
    ```bash
-   ./gradlew :monorepo-build-plugin:check
+   ./gradlew :monorepo-build-release-plugin:check
    ```
 
 2. **Validate plugin**: Check plugin configuration
    ```bash
-   ./gradlew :monorepo-build-plugin:validatePlugins
+   ./gradlew :monorepo-build-release-plugin:validatePlugins
    ```
 
 3. **Check code style**: Ensure code follows conventions
@@ -310,7 +306,7 @@ This triggers the release workflow.
 Publish to Maven Local for testing:
 
 ```bash
-./gradlew :monorepo-build-plugin:publishToMavenLocal
+./gradlew :monorepo-build-release-plugin:publishToMavenLocal
 ```
 
 Then in a test project:
@@ -320,7 +316,7 @@ repositories {
 }
 
 plugins {
-    id("io.github.doug-hawley.monorepo-build-plugin") version "1.1.0"
+    id("io.github.doug-hawley.monorepo-build-release-plugin") version "1.1.0"
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,1 +1,1 @@
-// Root build file — all plugin configuration lives in monorepo-build-plugin/build.gradle.kts
+// Root build file — all plugin configuration lives in monorepo-build-release-plugin/build.gradle.kts

--- a/examples/access-changed-files.gradle.kts
+++ b/examples/access-changed-files.gradle.kts
@@ -2,7 +2,7 @@
 // Place this in your root build.gradle.kts
 
 plugins {
-    id("io.github.doug-hawley.monorepo-build-plugin") version "0.3.2" // x-release-please-version
+    id("io.github.doug-hawley.monorepo-build-release-plugin") version "0.3.2" // x-release-please-version
 }
 
 monorepoBuild {


### PR DESCRIPTION
## Summary

Follow-up cleanup after merging the two plugins (#75). Several files still referenced the old module names and plugin IDs:

- `CLAUDE.md` — build commands, test paths, key classes table (added release classes), test structure (added integration tests), functional test file table (added 5 new task entries), release process path
- `CONTRIBUTING.md` — all Gradle task paths, project structure diagram, test structure section, JAR path, plugin ID example
- `examples/access-changed-files.gradle.kts` — plugin ID
- `.github/workflows/release-please.yml` — build, publish, and artifact upload paths
- `build.gradle.kts` (root) — comment

## Test plan

- [x] No source changes — docs and config only
- [x] `grep` confirms no remaining references to `monorepo-build-plugin` or `monorepo-release-plugin` in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)