### PR TITLE
chore: update repository URLs after rename to monorepo-build-release-plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,26 +24,24 @@ Thank you for your interest in contributing! This document provides guidelines a
 ### Clone the Repository
 
 ```bash
-git clone https://github.com/doug-hawley/monorepo-gradle-plugins.git
-cd monorepo-gradle-plugins
+git clone https://github.com/doug-hawley/monorepo-build-release-plugin.git
+cd monorepo-build-release-plugin
 ```
 
 ### Project Structure
 
 ```
-monorepo-gradle-plugins/
+monorepo-build-release-plugin/   ← repo root
 ├── src/
-│   ├── src/
-│   │   ├── main/kotlin/io/github/doughawley/monorepo/
-│   │   │   ├── MonorepoBuildReleasePlugin.kt   # plugin entry point
-│   │   │   ├── build/                           # change detection
-│   │   │   ├── release/                         # versioned tagging
-│   │   │   └── git/                             # shared git utilities
-│   │   └── test/
-│   │       ├── unit/kotlin/           # Unit tests
-│   │       ├── integration/kotlin/    # Integration tests (real git, no TestKit)
-│   │       └── functional/kotlin/    # Functional tests with Gradle TestKit
-│   └── build.gradle.kts
+│   ├── main/kotlin/io/github/doughawley/monorepo/
+│   │   ├── MonorepoBuildReleasePlugin.kt   # plugin entry point
+│   │   ├── build/                           # change detection
+│   │   ├── release/                         # versioned tagging
+│   │   └── git/                             # shared git utilities
+│   └── test/
+│       ├── unit/kotlin/           # Unit tests
+│       ├── integration/kotlin/    # Integration tests (real git, no TestKit)
+│       └── functional/kotlin/     # Functional tests with Gradle TestKit
 ├── build.gradle.kts
 ├── settings.gradle.kts
 └── gradle.properties
@@ -371,8 +369,8 @@ git diff --staged --name-only
 
 ## Need Help?
 
-- **Questions**: Open a [GitHub Discussion](https://github.com/doug-hawley/monorepo-gradle-plugins/discussions)
-- **Bugs**: Report via [GitHub Issues](https://github.com/doug-hawley/monorepo-gradle-plugins/issues)
+- **Questions**: Open a [GitHub Discussion](https://github.com/doug-hawley/monorepo-build-release-plugin/discussions)
+- **Bugs**: Report via [GitHub Issues](https://github.com/doug-hawley/monorepo-build-release-plugin/issues)
 
 ## License
 

--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -36,7 +36,7 @@ Your plugin is now configured and ready to publish! Here's what's already in pla
 
 ### Step 2: Add GitHub Secrets
 
-1. Go to your GitHub repository: https://github.com/doug-hawley/monorepo-gradle-plugins
+1. Go to your GitHub repository: https://github.com/doug-hawley/monorepo-build-release-plugin
 2. Navigate to: **Settings** → **Secrets and variables** → **Actions**
 3. Click **New repository secret**
 4. Add two secrets:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monorepo Build Plugin
 
-[![CI](https://github.com/doug-hawley/monorepo-gradle-plugins/actions/workflows/ci.yml/badge.svg)](https://github.com/doug-hawley/monorepo-gradle-plugins/actions/workflows/ci.yml)
+[![CI](https://github.com/doug-hawley/monorepo-build-release-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/doug-hawley/monorepo-build-release-plugin/actions/workflows/ci.yml)
 
 A Gradle plugin designed to optimize build times in large multi-module Gradle projects and monorepos by detecting which projects have changed based on git history.
 
@@ -228,9 +228,9 @@ This is expected if files in the root directory (outside of subproject directori
 
 ## Support & Contributions
 
-- **Issues**: Report bugs or request features via [GitHub Issues](https://github.com/doug-hawley/monorepo-gradle-plugins/issues)
+- **Issues**: Report bugs or request features via [GitHub Issues](https://github.com/doug-hawley/monorepo-build-release-plugin/issues)
 - **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines
-- **Questions**: Start a discussion in [GitHub Discussions](https://github.com/doug-hawley/monorepo-gradle-plugins/discussions)
+- **Questions**: Start a discussion in [GitHub Discussions](https://github.com/doug-hawley/monorepo-build-release-plugin/discussions)
 
 ## License
 

--- a/RESUBMISSION_GUIDE.md
+++ b/RESUBMISSION_GUIDE.md
@@ -15,7 +15,7 @@ This uses your GitHub username (`doug-hawley`) and follows the recommended `io.g
 The Gradle Plugin Portal requires public repositories.
 
 **Steps:**
-1. Go to: https://github.com/doug-hawley/monorepo-gradle-plugins/settings
+1. Go to: https://github.com/doug-hawley/monorepo-build-release-plugin/settings
 2. Scroll down to **"Danger Zone"** at the bottom
 3. Click **"Change visibility"**
 4. Select **"Make public"**
@@ -45,7 +45,7 @@ This proves you own the GitHub username `doug-hawley`.
 Before resubmitting, verify:
 
 ### Repository
-- [ ] Repository is **public** (https://github.com/doug-hawley/monorepo-gradle-plugins)
+- [ ] Repository is **public** (https://github.com/doug-hawley/monorepo-build-release-plugin)
 - [ ] Repository has a README with usage instructions
 - [ ] Repository has a LICENSE file
 - [ ] VCS URL in build.gradle.kts is correct

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,8 +117,8 @@ tasks.withType<Test>().configureEach {
 }
 
 gradlePlugin {
-    website.set("https://github.com/doug-hawley/monorepo-gradle-plugins")
-    vcsUrl.set("https://github.com/doug-hawley/monorepo-gradle-plugins.git")
+    website.set("https://github.com/doug-hawley/monorepo-build-release-plugin")
+    vcsUrl.set("https://github.com/doug-hawley/monorepo-build-release-plugin.git")
 
     plugins {
         register("monorepoBuildReleasePlugin") {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "release-type": "simple",
   "packages": {
     ".": {
-      "package-name": "monorepo-gradle-plugins",
+      "package-name": "monorepo-build-release-plugin",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary

Fixes stale `monorepo-gradle-plugins` references that weren't captured in the PR #79 squash merge:

- README.md: CI badge and links
- CONTRIBUTING.md: clone URL, `cd` command, project structure diagram (also fixes the stale `src/src/` nesting artifact)
- PUBLISHING_GUIDE.md, RESUBMISSION_GUIDE.md: GitHub repository links
- `build.gradle.kts`: `website` and `vcsUrl` in the `gradlePlugin` block (important for Gradle Plugin Portal submission)
- `release-please-config.json`: `package-name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)