### PR TITLE
chore: fix stale references after plugin merge and repo restructure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -177,17 +177,17 @@ if (exitCode == 0) {
 
 ### Running Tests
 ```bash
-./gradlew :monorepo-build-release-plugin:check
+./gradlew check
 ```
 
 ### Building the Plugin
 ```bash
-./gradlew :monorepo-build-release-plugin:build
+./gradlew build
 ```
 
 ### Publishing Locally
 ```bash
-./gradlew :monorepo-build-release-plugin:publishToMavenLocal
+./gradlew publishToMavenLocal
 ```
 
 ## CI/CD
@@ -227,7 +227,7 @@ GitHub Actions workflows are configured in `.github/workflows/`:
 ## Code Review Checklist
 
 Before submitting changes, verify:
-- [ ] All tests pass (`./gradlew :monorepo-build-release-plugin:check`)
+- [ ] All tests pass (`./gradlew check`)
 - [ ] Code compiles without warnings
 - [ ] New features have Kotest tests
 - [ ] Public APIs have KDoc comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,6 @@ This project uses [Kotest](https://kotest.io/) for testing with separate unit an
 
 For more information on testing, see:
 - [TEST_STRUCTURE.md](TEST_STRUCTURE.md)
-- [FUNCTIONAL_TESTS_GUIDE.md](FUNCTIONAL_TESTS_GUIDE.md)
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ An empty file is written when nothing has changed, so downstream scripts can alw
 **Override the output path permanently in the build script:**
 
 ```kotlin
-tasks.named<io.github.doughawley.monorepobuild.WriteChangedProjectsFromRefTask>(
+tasks.named<io.github.doughawley.monorepo.build.task.WriteChangedProjectsFromRefTask>(
     "writeChangedProjectsFromRef"
 ) {
     outputFile.set(layout.projectDirectory.file("ci/changed-projects.txt"))
@@ -153,7 +153,7 @@ The plugin computes results during the configuration phase, so any task can acce
 tasks.register("customTask") {
     doLast {
         val extension = project.extensions.getByType(
-            io.github.doughawley.monorepobuild.MonorepoBuildExtension::class.java
+            io.github.doughawley.monorepo.build.MonorepoBuildExtension::class.java
         )
         val changedProjects = extension.allAffectedProjects
         println("Changed projects: $changedProjects")

--- a/examples/access-changed-files.gradle.kts
+++ b/examples/access-changed-files.gradle.kts
@@ -17,7 +17,7 @@ monorepoBuild {
 tasks.register("listChangedProjects") {
     doLast {
         val extension = project.extensions.getByType(
-            io.github.doughawley.monorepobuild.MonorepoBuildExtension::class.java
+            io.github.doughawley.monorepo.build.MonorepoBuildExtension::class.java
         )
         println("Changed projects: ${extension.allAffectedProjects.joinToString(", ")}")
     }
@@ -27,7 +27,7 @@ tasks.register("listChangedProjects") {
 tasks.register("listChangedFiles") {
     doLast {
         val extension = project.extensions.getByType(
-            io.github.doughawley.monorepobuild.MonorepoBuildExtension::class.java
+            io.github.doughawley.monorepo.build.MonorepoBuildExtension::class.java
         )
 
         println("Changed files by project:")
@@ -44,7 +44,7 @@ tasks.register("listChangedFiles") {
 tasks.register("analyzeChanges") {
     doLast {
         val extension = project.extensions.getByType(
-            io.github.doughawley.monorepobuild.MonorepoBuildExtension::class.java
+            io.github.doughawley.monorepo.build.MonorepoBuildExtension::class.java
         )
 
         println("Detailed change analysis:")
@@ -68,7 +68,7 @@ tasks.register("analyzeChanges") {
 tasks.register("smartBuild") {
     doLast {
         val extension = project.extensions.getByType(
-            io.github.doughawley.monorepobuild.MonorepoBuildExtension::class.java
+            io.github.doughawley.monorepo.build.MonorepoBuildExtension::class.java
         )
 
         extension.changedFilesMap.forEach { (projectPath, files) ->
@@ -97,7 +97,7 @@ tasks.register("smartBuild") {
 tasks.register("impactReport") {
     doLast {
         val extension = project.extensions.getByType(
-            io.github.doughawley.monorepobuild.MonorepoBuildExtension::class.java
+            io.github.doughawley.monorepo.build.MonorepoBuildExtension::class.java
         )
 
         val report = StringBuilder()


### PR DESCRIPTION
## Summary

Cleans up stale references missed during the plugin consolidation and restructure:

- **`examples/access-changed-files.gradle.kts`**: 5 occurrences of `io.github.doughawley.monorepobuild.MonorepoBuildExtension` updated to `io.github.doughawley.monorepo.build.MonorepoBuildExtension` — users copying this example would have gotten compile errors
- **`README.md`**: Same package fix for `MonorepoBuildExtension` and `WriteChangedProjectsFromRefTask` (which also needed the `.task` subpackage added)
- **`.github/copilot-instructions.md`**: 4 Gradle task commands still had the old `:monorepo-build-release-plugin:` subproject prefix; tasks now run at root
- **`CONTRIBUTING.md`**: Removed broken link to `FUNCTIONAL_TESTS_GUIDE.md` which doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)