### PR TITLE
fix: gracefully handle initial commit when using relative parent refs

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
@@ -41,12 +41,32 @@ open class GitRepository(
         val dir = gitDir ?: return emptyList()
         val result = gitExecutor.execute(dir, "diff", "--name-only", commitRef, "HEAD")
         if (!result.success) {
+            if (isRelativeParentRef(commitRef) && isInitialCommit(dir)) {
+                logger.lifecycle(
+                    "Commit ref '$commitRef' does not exist, but this appears to be the initial commit. " +
+                    "Treating all files as changed."
+                )
+                return diffFromEmptyTree(dir)
+            }
             throw IllegalArgumentException(
                 "Commit ref '$commitRef' does not exist in this repository. " +
                 "Check the value passed to commitRef / -Pmonorepo.commitRef."
             )
         }
         return result.output
+    }
+
+    private fun isRelativeParentRef(ref: String): Boolean {
+        return ref.contains("~") || ref.contains("^")
+    }
+
+    private fun isInitialCommit(dir: File): Boolean {
+        val result = gitExecutor.execute(dir, "rev-list", "--count", "HEAD")
+        return result.success && result.output.firstOrNull()?.trim() == "1"
+    }
+
+    private fun diffFromEmptyTree(dir: File): List<String> {
+        return gitExecutor.executeForOutput(dir, "diff-tree", "--root", "--name-only", "--no-commit-id", "-r", "HEAD")
     }
 
     /** Returns files modified in the working tree but not yet staged. */

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFromRefFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFromRefFunctionalTest.kt
@@ -16,16 +16,16 @@ import org.gradle.testkit.runner.TaskOutcome
 class BuildChangedProjectsFromRefFunctionalTest : FunSpec({
     val testProjectListener = listener(TestProjectListener())
 
-    test("buildChangedProjectsFromRef fails with helpful error when no commitRef provided") {
+    test("buildChangedProjectsFromRef succeeds on initial commit with default HEAD~1 by treating all files as changed") {
         // given
         val project = testProjectListener.createStandardProject()
 
-        // when: run without commitRef
-        val result = project.runTaskAndFail("buildChangedProjectsFromRef")
+        // when: run without commitRef (defaults to HEAD~1, which falls back to empty-tree diff on initial commit)
+        val result = project.runTask("buildChangedProjectsFromRef")
 
-        // then: error message mentions how to supply commitRef
-        result.output shouldContain "commitRef"
-        result.output shouldContain "monorepo.commitRef"
+        // then: build succeeds and reports initial commit fallback
+        result.task(":buildChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "initial commit"
     }
 
     test("buildChangedProjectsFromRef builds directly changed project") {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/PrintChangedProjectsFromRefFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/PrintChangedProjectsFromRefFunctionalTest.kt
@@ -16,16 +16,16 @@ import org.gradle.testkit.runner.TaskOutcome
 class PrintChangedProjectsFromRefFunctionalTest : FunSpec({
     val testProjectListener = listener(TestProjectListener())
 
-    test("printChangedProjectsFromRef fails with helpful error when no commitRef provided") {
+    test("printChangedProjectsFromRef succeeds on initial commit with default HEAD~1 by treating all files as changed") {
         // given
         val project = testProjectListener.createStandardProject()
 
-        // when: run without commitRef
-        val result = project.runTaskAndFail("printChangedProjectsFromRef")
+        // when: run without commitRef (defaults to HEAD~1, which falls back to empty-tree diff on initial commit)
+        val result = project.runTask("printChangedProjectsFromRef")
 
-        // then: error message mentions how to supply commitRef
-        result.output shouldContain "commitRef"
-        result.output shouldContain "monorepo.commitRef"
+        // then: build succeeds and reports initial commit fallback
+        result.task(":printChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "initial commit"
     }
 
     test("printChangedProjectsFromRef detects directly changed project using commit SHA") {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/WriteChangedProjectsFromRefFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/WriteChangedProjectsFromRefFunctionalTest.kt
@@ -19,16 +19,16 @@ import java.io.File
 class WriteChangedProjectsFromRefFunctionalTest : FunSpec({
     val testProjectListener = listener(TestProjectListener())
 
-    test("writeChangedProjectsFromRef fails with helpful error when no commitRef provided") {
+    test("writeChangedProjectsFromRef succeeds on initial commit with default HEAD~1 by treating all files as changed") {
         // given
         val project = testProjectListener.createStandardProject()
 
-        // when
-        val result = project.runTaskAndFail("writeChangedProjectsFromRef")
+        // when: run without commitRef (defaults to HEAD~1, which falls back to empty-tree diff on initial commit)
+        val result = project.runTask("writeChangedProjectsFromRef")
 
-        // then
-        result.output shouldContain "commitRef"
-        result.output shouldContain "monorepo.commitRef"
+        // then: build succeeds and reports initial commit fallback
+        result.task(":writeChangedProjectsFromRef")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "initial commit"
     }
 
     test("writeChangedProjectsFromRef writes changed project paths to default output file") {

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
@@ -108,9 +108,25 @@ class GitRepositoryTest : FunSpec({
     }
 
     test("diffFromRef throws IllegalArgumentException when ref does not exist") {
+        // given — add a second commit so this is NOT an initial-commit repo
+        File(repoDir, "second.txt").writeText("second")
+        git(repoDir, "add", "second.txt")
+        git(repoDir, "commit", "-m", "second commit")
+
+        // when / then
         shouldThrow<IllegalArgumentException> {
             GitRepository(repoDir, logger).diffFromRef("nonexistent-ref-xyz")
         }
+    }
+
+    test("diffFromRef falls back to empty-tree diff on initial commit when ref does not exist") {
+        // given — repo has only one commit (initial), so HEAD~1 does not exist
+
+        // when
+        val result = GitRepository(repoDir, logger).diffFromRef("HEAD~1")
+
+        // then — all files from the initial commit are returned
+        result shouldContain "initial.txt"
     }
 
     // --- workingTreeChanges ---


### PR DESCRIPTION
## Summary
- When a repo has only one commit (e.g., first push to main), `HEAD~1` does not exist, causing `createReleaseBranchesForChangedProjects` and other ref-based tasks to fail
- `GitRepository.diffFromRef()` now detects when the ref is a relative parent reference (`~` or `^`) and the repo has only one commit, and falls back to `git diff-tree --root` to list all files as changed
- Non-relative refs (e.g., explicit SHAs) that don't exist still throw `IllegalArgumentException` as before

## Test plan
- [x] Unit test: `diffFromRef` falls back to empty-tree diff on initial commit when relative parent ref doesn't exist
- [x] Unit test: `diffFromRef` still throws for nonexistent refs on repos with multiple commits
- [x] Functional tests updated to verify initial commit behavior for `printChangedProjectsFromRef`, `buildChangedProjectsFromRef`, and `writeChangedProjectsFromRef`
- [x] Full `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)