### PR TITLE
fix: use branch version line for initial release on release branches

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolver.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolver.kt
@@ -1,0 +1,38 @@
+package io.github.doughawley.monorepo.release.domain
+
+/**
+ * Computes the next release version based on the current branch context,
+ * the latest existing version, and the requested scope.
+ */
+object NextVersionResolver {
+
+    /**
+     * Resolves the next version for a release from the primary branch (e.g., main).
+     *
+     * @param latestVersion the highest existing version across all version lines, or null if no tags exist
+     * @param scope the bump scope (MINOR or MAJOR)
+     */
+    fun forPrimaryBranch(latestVersion: SemanticVersion?, scope: Scope): SemanticVersion {
+        return if (latestVersion == null) {
+            SemanticVersion(0, 1, 0)
+        } else {
+            latestVersion.bump(scope)
+        }
+    }
+
+    /**
+     * Resolves the next version for a patch release from a release branch.
+     *
+     * @param latestInLine the highest existing version within this version line, or null if no tags exist for it
+     * @param major the major version from the release branch name
+     * @param minor the minor version from the release branch name
+     * @param scope the bump scope (always PATCH on release branches)
+     */
+    fun forReleaseBranch(latestInLine: SemanticVersion?, major: Int, minor: Int, scope: Scope): SemanticVersion {
+        return if (latestInLine == null) {
+            SemanticVersion(major, minor, 0)
+        } else {
+            latestInLine.bump(scope)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/ReleaseTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/ReleaseTask.kt
@@ -2,6 +2,7 @@ package io.github.doughawley.monorepo.release.task
 
 import io.github.doughawley.monorepo.release.MonorepoReleaseConfigExtension
 import io.github.doughawley.monorepo.release.MonorepoReleaseExtension
+import io.github.doughawley.monorepo.release.domain.NextVersionResolver
 import io.github.doughawley.monorepo.release.domain.Scope
 import io.github.doughawley.monorepo.release.domain.SemanticVersion
 import io.github.doughawley.monorepo.release.domain.TagPattern
@@ -73,17 +74,13 @@ open class ReleaseTask : DefaultTask() {
             ?: TagPattern.deriveProjectTagPrefix(project.path)
 
         // 6. Scan tags to find next version
-        val latestVersion = if (isReleaseBranch) {
+        val nextVersion = if (isReleaseBranch) {
             val (major, minor) = TagPattern.parseVersionLineFromBranch(currentBranch)
-            gitTagScanner.findLatestVersionInLine(globalPrefix, projectPrefix, major, minor)
+            val latestInLine = gitTagScanner.findLatestVersionInLine(globalPrefix, projectPrefix, major, minor)
+            NextVersionResolver.forReleaseBranch(latestInLine, major, minor, scope)
         } else {
-            gitTagScanner.findLatestVersion(globalPrefix, projectPrefix)
-        }
-
-        val nextVersion = if (latestVersion == null) {
-            SemanticVersion(0, 1, 0)
-        } else {
-            latestVersion.bump(scope)
+            val latestVersion = gitTagScanner.findLatestVersion(globalPrefix, projectPrefix)
+            NextVersionResolver.forPrimaryBranch(latestVersion, scope)
         }
 
         // 7. Tag collision check

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseTaskFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseTaskFunctionalTest.kt
@@ -122,6 +122,43 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.remoteBranches() shouldNotContain "release/app/v0.1.x.x"
     }
 
+    test("on release branch with no prior tags in that version line creates correct initial version") {
+        // given: v0.1.0 exists on main; release/app/v0.2.x branch exists but has no v0.2.* tags
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createTag("release/app/v0.1.0")
+        project.pushTag("release/app/v0.1.0")
+
+        // Create and switch to a release branch for v0.2.x (no v0.2.* tags exist)
+        project.createBranch("release/app/v0.2.x")
+        project.executeGitPush("release/app/v0.2.x")
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTask(":app:release")
+
+        // then: should create v0.2.0, NOT v0.1.0
+        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteTags() shouldContain "release/app/v0.2.0"
+    }
+
+    test("on release branch v1.0.x with no prior tags in that line creates v1.0.0") {
+        // given: higher version line with no prior tags
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createTag("release/app/v0.1.0")
+        project.pushTag("release/app/v0.1.0")
+
+        project.createBranch("release/app/v1.0.x")
+        project.executeGitPush("release/app/v1.0.x")
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTask(":app:release")
+
+        // then
+        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteTags() shouldContain "release/app/v1.0.0"
+    }
+
     test("release branch ignores DSL primaryBranchScope and always uses patch") {
         // given: primaryBranchScope=major in DSL should have no effect on a release branch
         val project = StandardReleaseTestProject.createAndInitialize(

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolverTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolverTest.kt
@@ -1,0 +1,92 @@
+package io.github.doughawley.monorepo.release.domain
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class NextVersionResolverTest : FunSpec({
+
+    // ─────────────────────────────────────────────────────────────
+    // forPrimaryBranch
+    // ─────────────────────────────────────────────────────────────
+
+    test("forPrimaryBranch with no prior tags returns v0.1.0") {
+        // given
+        val latestVersion: SemanticVersion? = null
+
+        // when
+        val result = NextVersionResolver.forPrimaryBranch(latestVersion, Scope.MINOR)
+
+        // then
+        result shouldBe SemanticVersion(0, 1, 0)
+    }
+
+    test("forPrimaryBranch with existing tag bumps by scope") {
+        // given
+        val latestVersion = SemanticVersion(0, 1, 0)
+
+        // when
+        val result = NextVersionResolver.forPrimaryBranch(latestVersion, Scope.MINOR)
+
+        // then
+        result shouldBe SemanticVersion(0, 2, 0)
+    }
+
+    test("forPrimaryBranch with major scope bumps major") {
+        // given
+        val latestVersion = SemanticVersion(0, 3, 0)
+
+        // when
+        val result = NextVersionResolver.forPrimaryBranch(latestVersion, Scope.MAJOR)
+
+        // then
+        result shouldBe SemanticVersion(1, 0, 0)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // forReleaseBranch
+    // ─────────────────────────────────────────────────────────────
+
+    test("forReleaseBranch with no prior tags in version line returns major.minor.0") {
+        // given — on release branch v0.2.x with no v0.2.* tags
+        val latestInLine: SemanticVersion? = null
+
+        // when
+        val result = NextVersionResolver.forReleaseBranch(latestInLine, major = 0, minor = 2, Scope.PATCH)
+
+        // then — should be v0.2.0, NOT v0.1.0
+        result shouldBe SemanticVersion(0, 2, 0)
+    }
+
+    test("forReleaseBranch with no prior tags on v1.0.x returns v1.0.0") {
+        // given
+        val latestInLine: SemanticVersion? = null
+
+        // when
+        val result = NextVersionResolver.forReleaseBranch(latestInLine, major = 1, minor = 0, Scope.PATCH)
+
+        // then
+        result shouldBe SemanticVersion(1, 0, 0)
+    }
+
+    test("forReleaseBranch with existing tag bumps patch") {
+        // given — on release branch v0.1.x with v0.1.1 as latest
+        val latestInLine = SemanticVersion(0, 1, 1)
+
+        // when
+        val result = NextVersionResolver.forReleaseBranch(latestInLine, major = 0, minor = 1, Scope.PATCH)
+
+        // then
+        result shouldBe SemanticVersion(0, 1, 2)
+    }
+
+    test("forReleaseBranch with no prior tags on v3.5.x returns v3.5.0") {
+        // given
+        val latestInLine: SemanticVersion? = null
+
+        // when
+        val result = NextVersionResolver.forReleaseBranch(latestInLine, major = 3, minor = 5, Scope.PATCH)
+
+        // then
+        result shouldBe SemanticVersion(3, 5, 0)
+    }
+})


### PR DESCRIPTION
## Summary
- When releasing from a release branch (e.g., `release/app/v0.2.x`) with no prior tags in that version line, the version incorrectly defaulted to `v0.1.0` instead of `v0.2.0`
- Extracted `NextVersionResolver` with `forPrimaryBranch()` and `forReleaseBranch()` methods that correctly compute the initial version from the branch's major.minor components
- `ReleaseTask` now delegates version computation to `NextVersionResolver`

## Test plan
- [x] Unit tests (`NextVersionResolverTest`): 7 tests covering primary branch and release branch scenarios, including the bug case (no prior tags on v0.2.x → v0.2.0)
- [x] Functional tests (`ReleaseTaskFunctionalTest`): 2 new end-to-end tests verifying correct versioning on release branches with no prior tags (v0.2.x → v0.2.0, v1.0.x → v1.0.0)
- [x] Full `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)