### PR TITLE
feat: restrict release task to matching release branches only

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,21 +148,19 @@ Builds all opted-in projects that changed since the configured commit ref, then 
 
 #### `:subproject:release`
 
-Releases a single subproject manually, regardless of whether it changed:
+Releases a single subproject from its release branch. Must be run from a matching release branch (e.g., `:app1:release` must be run from `release/app1/v0.1.x`):
 
 ```bash
-# Release using the default scope
 ./gradlew :api:release
-
-# Override the version bump scope (primary branch only)
-./gradlew :api:release -Prelease.scope=major
 ```
+
+The task will fail if run from `main`, a feature branch, or a release branch belonging to a different project.
 
 #### Versioning rules
 
-- First release of a project starts at `0.1.0`
-- Releases from the primary branch bump using `primaryBranchScope` (default `minor`)
-- Releases from a release branch (`release/api/v1.2.x`) always apply a `patch` bump
+- Release branches follow the pattern `{globalTagPrefix}/{projectPrefix}/v{major}.{minor}.x`
+- The first release on a new branch (e.g., `release/api/v0.1.x`) creates `v0.1.0`
+- Subsequent releases on that branch apply a `patch` bump (`v0.1.1`, `v0.1.2`, …)
 - The subproject must be built before releasing — `release` requires `build` to have run
 
 ### Advanced
@@ -295,7 +293,7 @@ Applied per subproject. Patterns are matched against paths **relative to the sub
 |----------|------|---------|-------------|
 | `globalTagPrefix` | String | `"release"` | Prefix used in all tag and release branch names |
 | `primaryBranchScope` | String | `"minor"` | Version bump scope when releasing from the primary branch; `"minor"` or `"major"` |
-| `releaseBranchPatterns` | List\<String\> | `["^main$", "^release/.*"]` | Regex patterns for branches from which releases are permitted |
+| `releaseBranchPatterns` | List\<String\> | `["^main$", "^release/.*"]` | Regex patterns for branches from which `createReleaseBranchesForChangedProjects` is permitted to run |
 
 ### `monorepoProject { release { } }`
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolver.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolver.kt
@@ -7,20 +7,6 @@ package io.github.doughawley.monorepo.release.domain
 object NextVersionResolver {
 
     /**
-     * Resolves the next version for a release from the primary branch (e.g., main).
-     *
-     * @param latestVersion the highest existing version across all version lines, or null if no tags exist
-     * @param scope the bump scope (MINOR or MAJOR)
-     */
-    fun forPrimaryBranch(latestVersion: SemanticVersion?, scope: Scope): SemanticVersion {
-        return if (latestVersion == null) {
-            SemanticVersion(0, 1, 0)
-        } else {
-            latestVersion.bump(scope)
-        }
-    }
-
-    /**
      * Resolves the next version for a patch release from a release branch.
      *
      * @param latestInLine the highest existing version within this version line, or null if no tags exist for it

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/domain/TagPattern.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/domain/TagPattern.kt
@@ -35,4 +35,10 @@ object TagPattern {
             )
         return Pair(match.groupValues[1].toInt(), match.groupValues[2].toInt())
     }
+
+    fun parseProjectPrefixFromBranch(branch: String, globalPrefix: String): String {
+        // Expected format: <globalPrefix>/<projectPrefix>/v<major>.<minor>.x
+        val withoutGlobal = branch.removePrefix("$globalPrefix/")
+        return withoutGlobal.substringBeforeLast("/")
+    }
 }

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/ReleaseTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/ReleaseTask.kt
@@ -4,7 +4,6 @@ import io.github.doughawley.monorepo.release.MonorepoReleaseConfigExtension
 import io.github.doughawley.monorepo.release.MonorepoReleaseExtension
 import io.github.doughawley.monorepo.release.domain.NextVersionResolver
 import io.github.doughawley.monorepo.release.domain.Scope
-import io.github.doughawley.monorepo.release.domain.SemanticVersion
 import io.github.doughawley.monorepo.release.domain.TagPattern
 import io.github.doughawley.monorepo.release.git.GitReleaseExecutor
 import io.github.doughawley.monorepo.release.git.GitTagScanner
@@ -45,7 +44,7 @@ open class ReleaseTask : DefaultTask() {
             )
         }
 
-        // 3. Branch validation
+        // 3. Branch validation — must be on a release branch
         val globalPrefix = rootExtension.globalTagPrefix
         val currentBranch = gitReleaseExecutor.currentBranch()
         if (currentBranch == "HEAD") {
@@ -54,36 +53,36 @@ open class ReleaseTask : DefaultTask() {
                 "Check out a branch before releasing."
             )
         }
-        val isReleaseBranch = TagPattern.isReleaseBranch(currentBranch, globalPrefix)
-        val isAllowedBranch = isReleaseBranch || rootExtension.releaseBranchPatterns.any { pattern ->
-            currentBranch.matches(Regex(pattern))
-        }
-        if (!isAllowedBranch) {
+        if (!TagPattern.isReleaseBranch(currentBranch, globalPrefix)) {
             throw GradleException(
                 "Cannot release from branch '$currentBranch'. " +
-                "Releases must be made from a configured release branch. " +
-                "Allowed patterns: ${rootExtension.releaseBranchPatterns.joinToString(", ")}"
+                "Releases must be made from a release branch " +
+                "(e.g., $globalPrefix/<project>/v<major>.<minor>.x)."
             )
         }
 
-        // 4. Scope resolution
-        val scope = resolveScope(isReleaseBranch)
-
-        // 5. Determine tag prefix
+        // 4. Determine tag prefix
         val projectPrefix = projectConfig.tagPrefix
             ?: TagPattern.deriveProjectTagPrefix(project.path)
 
-        // 6. Scan tags to find next version
-        val nextVersion = if (isReleaseBranch) {
-            val (major, minor) = TagPattern.parseVersionLineFromBranch(currentBranch)
-            val latestInLine = gitTagScanner.findLatestVersionInLine(globalPrefix, projectPrefix, major, minor)
-            NextVersionResolver.forReleaseBranch(latestInLine, major, minor, scope)
-        } else {
-            val latestVersion = gitTagScanner.findLatestVersion(globalPrefix, projectPrefix)
-            NextVersionResolver.forPrimaryBranch(latestVersion, scope)
+        // 5. Branch-to-project validation
+        val branchProjectPrefix = TagPattern.parseProjectPrefixFromBranch(currentBranch, globalPrefix)
+        if (branchProjectPrefix != projectPrefix) {
+            throw GradleException(
+                "Cannot release ${project.path} from branch '$currentBranch'. " +
+                "This branch is for project '$branchProjectPrefix', not '$projectPrefix'."
+            )
         }
 
-        // 7. Tag collision check
+        // 6. Scope validation
+        val scope = resolveScope()
+
+        // 7. Scan tags to find next version
+        val (major, minor) = TagPattern.parseVersionLineFromBranch(currentBranch)
+        val latestInLine = gitTagScanner.findLatestVersionInLine(globalPrefix, projectPrefix, major, minor)
+        val nextVersion = NextVersionResolver.forReleaseBranch(latestInLine, major, minor, scope)
+
+        // 8. Tag collision check
         val tag = TagPattern.formatTag(globalPrefix, projectPrefix, nextVersion)
         if (gitTagScanner.tagExists(tag)) {
             throw GradleException(
@@ -92,7 +91,7 @@ open class ReleaseTask : DefaultTask() {
             )
         }
 
-        // 8. Build outputs check
+        // 9. Build outputs check
         val libsDir = project.layout.buildDirectory.dir("libs").get().asFile
         val libsFiles = libsDir.listFiles()
         if (!libsDir.exists() || libsFiles == null || libsFiles.isEmpty()) {
@@ -101,26 +100,12 @@ open class ReleaseTask : DefaultTask() {
             )
         }
 
-        // 9. Set project.version
+        // 10. Set project.version
         project.version = nextVersion.toString()
         logger.lifecycle("Releasing ${project.path} as version $nextVersion")
 
-        // 10. Create tag locally
+        // 11. Create tag locally
         gitReleaseExecutor.createTagLocally(tag)
-
-        // 11. Create release branch locally (only when not on a release branch)
-        val releaseBranch: String? = if (!isReleaseBranch) {
-            val branch = TagPattern.formatReleaseBranch(globalPrefix, projectPrefix, nextVersion)
-            try {
-                gitReleaseExecutor.createBranchLocally(branch)
-            } catch (e: GradleException) {
-                gitReleaseExecutor.deleteLocalTag(tag)
-                throw e
-            }
-            branch
-        } else {
-            null
-        }
 
         // 12. Push to remote (with rollback on failure)
         try {
@@ -128,23 +113,7 @@ open class ReleaseTask : DefaultTask() {
         } catch (e: GradleException) {
             logger.error("Push failed, rolling back local changes: ${e.message}")
             gitReleaseExecutor.deleteLocalTag(tag)
-            if (releaseBranch != null) {
-                gitReleaseExecutor.deleteLocalBranch(releaseBranch)
-            }
             throw e
-        }
-        if (releaseBranch != null) {
-            try {
-                gitReleaseExecutor.pushBranch(releaseBranch)
-            } catch (e: GradleException) {
-                gitReleaseExecutor.deleteLocalTag(tag)
-                gitReleaseExecutor.deleteLocalBranch(releaseBranch)
-                logger.error(
-                    "Branch push failed. Tag '$tag' was already pushed to remote — " +
-                    "it cannot be rolled back automatically."
-                )
-                throw e
-            }
         }
 
         // 13. Write build/release-version.txt
@@ -154,25 +123,7 @@ open class ReleaseTask : DefaultTask() {
         logger.lifecycle("Wrote release version to: ${versionFile.absolutePath}")
     }
 
-    private fun resolveScope(isReleaseBranch: Boolean): Scope {
-        if (isReleaseBranch) {
-            val scopeProperty = project.findProperty("release.scope") as? String
-            if (scopeProperty != null) {
-                val parsed = Scope.fromString(scopeProperty)
-                    ?: throw GradleException(
-                        "Invalid release.scope value: '$scopeProperty'. " +
-                        "Must be one of: major, minor, patch"
-                    )
-                if (parsed != Scope.PATCH) {
-                    throw GradleException(
-                        "Cannot use scope '$scopeProperty' on a release branch. " +
-                        "Patch releases only — remove the -Prelease.scope flag or use 'patch'."
-                    )
-                }
-            }
-            return Scope.PATCH
-        }
-
+    private fun resolveScope(): Scope {
         val scopeProperty = project.findProperty("release.scope") as? String
         if (scopeProperty != null) {
             val parsed = Scope.fromString(scopeProperty)
@@ -180,28 +131,14 @@ open class ReleaseTask : DefaultTask() {
                     "Invalid release.scope value: '$scopeProperty'. " +
                     "Must be one of: major, minor, patch"
                 )
-            if (parsed == Scope.PATCH) {
+            if (parsed != Scope.PATCH) {
                 throw GradleException(
-                    "Cannot use scope 'patch' on the main branch. " +
-                    "Use 'minor' or 'major' for new feature releases."
+                    "Cannot use scope '$scopeProperty' on a release branch. " +
+                    "Patch releases only — remove the -Prelease.scope flag or use 'patch'."
                 )
             }
-            return parsed
         }
-
-        val dslScope = Scope.fromString(rootExtension.primaryBranchScope)
-            ?: throw GradleException(
-                "Invalid primaryBranchScope in monorepo { release { } } DSL: " +
-                "'${rootExtension.primaryBranchScope}'. " +
-                "Must be one of: major, minor"
-            )
-        if (dslScope == Scope.PATCH) {
-            throw GradleException(
-                "Cannot configure primaryBranchScope as 'patch' on the main branch. " +
-                "Use 'minor' or 'major'."
-            )
-        }
-        return dslScope
+        return Scope.PATCH
     }
 
 }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseTaskFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseTaskFunctionalTest.kt
@@ -3,7 +3,6 @@ package io.github.doughawley.monorepo.release.functional
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -18,9 +17,11 @@ class ReleaseTaskFunctionalTest : FunSpec({
     // Core versioning
     // ─────────────────────────────────────────────────────────────
 
-    test("no prior tag creates first release as v0.1.0 with tag and release branch") {
+    test("no prior tag on release branch creates first release as major.minor.0") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -30,14 +31,15 @@ class ReleaseTaskFunctionalTest : FunSpec({
         result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
         project.localTags() shouldContain "release/app/v0.1.0"
         project.remoteTags() shouldContain "release/app/v0.1.0"
-        project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
 
-    test("prior v0.1.0 tag with default minor scope creates v0.2.0") {
+    test("prior tag in version line bumps patch") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
         project.createTag("release/app/v0.1.0")
         project.pushTag("release/app/v0.1.0")
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -45,56 +47,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
 
         // then
         result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v0.2.0"
-    }
-
-    test("-Prelease.scope=major bumps major version") {
-        // given
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createTag("release/app/v0.1.0")
-        project.pushTag("release/app/v0.1.0")
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTask(":app:release", properties = mapOf("release.scope" to "major"))
-
-        // then
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v1.0.0"
-    }
-
-    test("-Prelease.scope=minor bumps minor version") {
-        // given
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createTag("release/app/v0.1.0")
-        project.pushTag("release/app/v0.1.0")
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTask(":app:release", properties = mapOf("release.scope" to "minor"))
-
-        // then
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v0.2.0"
-    }
-
-    test("multiple version lines on main scans global latest for next minor") {
-        // given: v0.1.2 and v0.2.0 exist — global latest is v0.2.0 → next minor is v0.3.0
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createTag("release/app/v0.1.0")
-        project.createTag("release/app/v0.1.2")
-        project.createTag("release/app/v0.2.0")
-        project.pushTag("release/app/v0.1.0")
-        project.pushTag("release/app/v0.1.2")
-        project.pushTag("release/app/v0.2.0")
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTask(":app:release")
-
-        // then
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v0.3.0"
+        project.remoteTags() shouldContain "release/app/v0.1.1"
     }
 
     test("on release branch scans only version line and creates patch") {
@@ -107,7 +60,6 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.pushTag("release/app/v0.1.1")
         project.pushTag("release/app/v0.2.0")
 
-        // Create and switch to a release branch (push to remote so it exists there)
         project.createBranch("release/app/v0.1.x")
         project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
@@ -118,17 +70,14 @@ class ReleaseTaskFunctionalTest : FunSpec({
         // then
         result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteTags() shouldContain "release/app/v0.1.2"
-        // Should NOT create another release branch
-        project.remoteBranches() shouldNotContain "release/app/v0.1.x.x"
     }
 
     test("on release branch with no prior tags in that version line creates correct initial version") {
-        // given: v0.1.0 exists on main; release/app/v0.2.x branch exists but has no v0.2.* tags
+        // given: v0.1.0 exists; release/app/v0.2.x branch exists but has no v0.2.* tags
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
         project.createTag("release/app/v0.1.0")
         project.pushTag("release/app/v0.1.0")
 
-        // Create and switch to a release branch for v0.2.x (no v0.2.* tags exist)
         project.createBranch("release/app/v0.2.x")
         project.executeGitPush("release/app/v0.2.x")
         project.createFakeBuiltArtifact()
@@ -142,7 +91,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
     }
 
     test("on release branch v1.0.x with no prior tags in that line creates v1.0.0") {
-        // given: higher version line with no prior tags
+        // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
         project.createTag("release/app/v0.1.0")
         project.pushTag("release/app/v0.1.0")
@@ -159,26 +108,6 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.remoteTags() shouldContain "release/app/v1.0.0"
     }
 
-    test("release branch ignores DSL primaryBranchScope and always uses patch") {
-        // given: primaryBranchScope=major in DSL should have no effect on a release branch
-        val project = StandardReleaseTestProject.createAndInitialize(
-            testListener.getTestProjectDir(),
-            primaryBranchScope = "major"
-        )
-        project.createTag("release/app/v0.1.0")
-        project.pushTag("release/app/v0.1.0")
-        project.createBranch("release/app/v0.1.x")
-        project.executeGitPush("release/app/v0.1.x")
-        project.createFakeBuiltArtifact()
-
-        // when: no scope flag provided
-        val result = project.runTask(":app:release")
-
-        // then: patch applied, not major
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v0.1.1"
-    }
-
     // ─────────────────────────────────────────────────────────────
     // Tag format
     // ─────────────────────────────────────────────────────────────
@@ -186,6 +115,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
     test("single-level path :app produces tag release/app/v...") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -198,6 +129,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
     test("custom globalTagPrefix overrides default release prefix") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir(), globalTagPrefix = "publish")
+        project.createBranch("publish/app/v0.1.x")
+        project.executeGitPush("publish/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -209,7 +142,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
     }
 
     test("custom tagPrefix in monorepoProject { release { } } overrides path-derived value") {
-        // given: set up project with custom tagPrefix
+        // given
         val projectDir = testListener.getTestProjectDir()
         val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
 
@@ -249,6 +182,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.initGit()
         project.commitAll("Initial commit")
         project.pushToRemote()
+        project.createBranch("release/my-custom-app/v0.1.x")
+        project.executeGitPush("release/my-custom-app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -298,6 +233,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.initGit()
         project.commitAll("Initial commit")
         project.pushToRemote()
+        project.createBranch("release/services-auth/v0.1.x")
+        project.executeGitPush("release/services-auth/v0.1.x")
         File(projectDir, "services/auth/build/libs").mkdirs()
         File(projectDir, "services/auth/build/libs/auth.jar").writeText("fake jar content")
 
@@ -310,12 +247,113 @@ class ReleaseTaskFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
+    // Branch restrictions
+    // ─────────────────────────────────────────────────────────────
+
+    test("release from main fails with clear message") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTaskAndFail(":app:release")
+
+        // then
+        result.output shouldContain "Cannot release from branch 'main'"
+        result.output shouldContain "release branch"
+    }
+
+    test("feature branch causes release to fail with clear message") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("feature/my-feature")
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTaskAndFail(":app:release")
+
+        // then
+        result.output shouldContain "Cannot release from branch 'feature/my-feature'"
+        result.output shouldContain "release branch"
+    }
+
+    test("detached HEAD fails with clear message") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.detachHead()
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTaskAndFail(":app:release")
+
+        // then
+        result.output shouldContain "Cannot release from a detached HEAD state. Check out a branch before releasing."
+    }
+
+    test("release from wrong project release branch fails with clear message") {
+        // given: on release/app/v0.1.x, try to release :lib
+        val projectDir = testListener.getTestProjectDir()
+        val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
+
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("io.github.doug-hawley.monorepo-build-release-plugin")
+            }
+            """.trimIndent()
+        )
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            rootProject.name = "test-project"
+            include(":app")
+            include(":lib")
+            """.trimIndent()
+        )
+        File(projectDir, ".gitignore").writeText(".gradle/\nbuild/")
+
+        listOf("app", "lib").forEach { name ->
+            val dir = File(projectDir, name)
+            dir.mkdirs()
+            File(dir, "build.gradle.kts").writeText(
+                """
+                plugins {
+                    kotlin("jvm") version "2.0.21"
+                }
+                monorepoProject {
+                    release {
+                        enabled = true
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        val project = ReleaseTestProject(projectDir, remoteDir)
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
+        File(projectDir, "lib/build/libs").mkdirs()
+        File(projectDir, "lib/build/libs/lib.jar").writeText("fake jar content")
+
+        // when: try to release :lib from :app's release branch
+        val result = project.runTaskAndFail(":lib:release")
+
+        // then
+        result.output shouldContain "Cannot release :lib from branch 'release/app/v0.1.x'"
+        result.output shouldContain "This branch is for project 'app', not 'lib'"
+    }
+
+    // ─────────────────────────────────────────────────────────────
     // Guardrails
     // ─────────────────────────────────────────────────────────────
 
     test("uncommitted changes causes release to fail with clear message") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
         project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// modified content")
 
@@ -329,6 +367,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
     test("staged but uncommitted changes causes release to fail") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
         project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// staged modification")
         project.stageFile("app/src/main/kotlin/com/example/App.kt")
@@ -340,94 +380,29 @@ class ReleaseTaskFunctionalTest : FunSpec({
         result.output shouldContain "Cannot release with uncommitted changes. Please commit or stash all changes before releasing."
     }
 
-    test("feature branch causes release to fail with clear message") {
+    test("tag already exists causes release to fail with clear message") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createBranch("feature/my-feature")
+        project.createTag("release/app/v0.1.0")
+        project.pushTag("release/app/v0.1.0")
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
+        // Create v0.1.1 locally only (not pushed) — this is the "collision" tag
+        project.createTag("release/app/v0.1.1")
         project.createFakeBuiltArtifact()
 
         // when
         val result = project.runTaskAndFail(":app:release")
 
-        // then: message names the offending branch and tells the user which branches are allowed
-        result.output shouldContain "Cannot release from branch 'feature/my-feature'"
-        result.output shouldContain "Allowed patterns"
-    }
-
-    test("custom releaseBranchPatterns restricts valid branches") {
-        // given: configure only 'develop' as a valid release branch
-        val projectDir = testListener.getTestProjectDir()
-        val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
-
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                id("io.github.doug-hawley.monorepo-build-release-plugin")
-            }
-
-            monorepo {
-                release {
-                    releaseBranchPatterns = listOf("^develop${'$'}")
-                }
-            }
-            """.trimIndent()
-        )
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            rootProject.name = "test-project"
-            include(":app")
-            """.trimIndent()
-        )
-        File(projectDir, ".gitignore").writeText(".gradle/\nbuild/")
-        val appDir = File(projectDir, "app")
-        appDir.mkdirs()
-        File(appDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                kotlin("jvm") version "2.0.21"
-            }
-            monorepoProject {
-                release {
-                    enabled = true
-                }
-            }
-            """.trimIndent()
-        )
-
-        val project = ReleaseTestProject(projectDir, remoteDir)
-        project.initGit()
-        project.commitAll("Initial commit")
-        project.pushToRemote()
-        project.createFakeBuiltArtifact()
-
-        // when: on 'main' which is not in the custom patterns
-        val result = project.runTaskAndFail(":app:release")
-
-        // then: message names the offending branch and shows the configured allowed patterns
-        result.output shouldContain "Cannot release from branch 'main'"
-        result.output shouldContain "Allowed patterns: ^develop$"
-    }
-
-    test("tag already exists causes release to fail with clear message") {
-        // given: v0.1.0 is the latest released version (on remote); v0.2.0 was created locally
-        // (e.g. a previous failed release attempt left the local tag behind)
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createTag("release/app/v0.1.0")
-        project.pushTag("release/app/v0.1.0")
-        // Create v0.2.0 locally only (not pushed) — this is the "collision" tag
-        project.createTag("release/app/v0.2.0")
-        project.createFakeBuiltArtifact()
-
-        // when: scanner finds v0.1.0 on remote → next = v0.2.0; tagExists finds local v0.2.0 → fail
-        val result = project.runTaskAndFail(":app:release")
-
         // then
-        result.output shouldContain "Tag 'release/app/v0.2.0' already exists. This version has already been released."
+        result.output shouldContain "Tag 'release/app/v0.1.1' already exists. This version has already been released."
     }
 
     test("build outputs missing causes release to fail mentioning build task") {
-        // given: no fake artifact created
+        // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
 
         // when
         val result = project.runTaskAndFail(":app:release")
@@ -439,6 +414,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
     test("build outputs present allows release to proceed") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -451,18 +428,6 @@ class ReleaseTaskFunctionalTest : FunSpec({
     // ─────────────────────────────────────────────────────────────
     // Scope enforcement
     // ─────────────────────────────────────────────────────────────
-
-    test("main + -Prelease.scope=patch fails with clear message") {
-        // given
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTaskAndFail(":app:release", properties = mapOf("release.scope" to "patch"))
-
-        // then
-        result.output shouldContain "Cannot use scope 'patch' on the main branch. Use 'minor' or 'major' for new feature releases."
-    }
 
     test("release branch with -Prelease.scope=minor fails with clear message") {
         // given
@@ -516,6 +481,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
     test("invalid -Prelease.scope value fails with clear message") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -525,41 +492,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
         result.output shouldContain "Invalid release.scope value: 'bogus'. Must be one of: major, minor, patch"
     }
 
-    test("DSL primaryBranchScope = \"major\" bumps major version") {
-        // given: prior v0.1.0 exists; major scope via DSL should produce v1.0.0
-        val project = StandardReleaseTestProject.createAndInitialize(
-            testListener.getTestProjectDir(),
-            primaryBranchScope = "major"
-        )
-        project.createTag("release/app/v0.1.0")
-        project.pushTag("release/app/v0.1.0")
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTask(":app:release")
-
-        // then
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v1.0.0"
-    }
-
-    test("DSL primaryBranchScope = \"patch\" on main fails with clear message") {
-        // given
-        val project = StandardReleaseTestProject.createAndInitialize(
-            testListener.getTestProjectDir(),
-            primaryBranchScope = "patch"
-        )
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTaskAndFail(":app:release")
-
-        // then
-        result.output shouldContain "Cannot configure primaryBranchScope as 'patch' on the main branch. Use 'minor' or 'major'."
-    }
-
     test("release branch accepts -Prelease.scope=patch and applies patch") {
-        // given: on a release branch, explicit patch scope should be accepted (not rejected)
+        // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
         project.createTag("release/app/v0.1.0")
         project.pushTag("release/app/v0.1.0")
@@ -579,7 +513,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
     // Push and rollback
     // ─────────────────────────────────────────────────────────────
 
-    test("push fails when no remote configured — local tag and branch are deleted, task fails cleanly") {
+    test("push fails when no remote configured — local tag is deleted, task fails cleanly") {
         // given: project without remote
         val projectDir = testListener.getTestProjectDir()
         File(projectDir, "build.gradle.kts").writeText(
@@ -611,17 +545,15 @@ class ReleaseTaskFunctionalTest : FunSpec({
             """.trimIndent()
         )
 
-        // Initialize without remote
         val noRemote = File(projectDir.parentFile, "${projectDir.name}-no-remote.git")
         val project = ReleaseTestProject(projectDir, noRemote)
-        // Manual init without remote
         fun runGit(vararg cmd: String) {
             ProcessBuilder(*cmd).directory(projectDir).start().waitFor()
         }
         runGit("git", "init")
         runGit("git", "config", "user.email", "test@example.com")
         runGit("git", "config", "user.name", "Test User")
-        runGit("git", "checkout", "-b", "main")
+        runGit("git", "checkout", "-b", "release/app/v0.1.x")
         runGit("git", "add", ".")
         runGit("git", "commit", "-m", "Initial commit")
         project.createFakeBuiltArtifact()
@@ -634,7 +566,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.localTags() shouldNotContain "release/app/v0.1.0"
     }
 
-    test("on release branch no release branch is created, only tag pushed") {
+    test("on release branch no new release branch is created, only tag pushed") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
         project.createTag("release/app/v0.1.0")
@@ -646,10 +578,9 @@ class ReleaseTaskFunctionalTest : FunSpec({
         // when
         project.runTask(":app:release")
 
-        // then: new release branch not created
+        // then: no new branch created
         val remoteBranches = project.remoteBranches()
         remoteBranches shouldContain "release/app/v0.1.x"
-        // Should not contain a new branch like release/app/v0.1.x.x
         remoteBranches.filter { it.startsWith("release/app/v0.1.") && it != "release/app/v0.1.x" } shouldBe emptyList()
     }
 
@@ -660,6 +591,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
     test("build/release-version.txt is written after successful release") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -674,7 +607,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
     // ─────────────────────────────────────────────────────────────
 
     test("postRelease task runs after successful release") {
-        // given: wire a task to postRelease via finalizedBy in a custom subproject build
+        // given
         val projectDir = testListener.getTestProjectDir()
         val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
 
@@ -716,6 +649,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.initGit()
         project.commitAll("Initial commit")
         project.pushToRemote()
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         project.createFakeBuiltArtifact()
 
         // when
@@ -769,6 +704,8 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.initGit()
         project.commitAll("Initial commit")
         project.pushToRemote()
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         // deliberately no createFakeBuiltArtifact()
 
         // when
@@ -783,7 +720,7 @@ class ReleaseTaskFunctionalTest : FunSpec({
     // ─────────────────────────────────────────────────────────────
 
     test("subproject without monorepoProject { release { } } has no release task") {
-        // given: a project where no subproject has enabled opt-in
+        // given
         val projectDir = testListener.getTestProjectDir()
         val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
 
@@ -803,7 +740,6 @@ class ReleaseTaskFunctionalTest : FunSpec({
         File(projectDir, ".gitignore").writeText(".gradle/\nbuild/")
         val libDir = File(projectDir, "lib")
         libDir.mkdirs()
-        // No monorepoProject { release { } } block at all
         File(libDir, "build.gradle.kts").writeText(
             """
             plugins {
@@ -822,103 +758,6 @@ class ReleaseTaskFunctionalTest : FunSpec({
 
         // then: task does not exist
         result.output shouldContain "release"
-    }
-
-    // ─────────────────────────────────────────────────────────────
-    // New gap-fix tests
-    // ─────────────────────────────────────────────────────────────
-
-    test("detached HEAD fails with clear message") {
-        // given
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.detachHead()
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTaskAndFail(":app:release")
-
-        // then
-        result.output shouldContain "Cannot release from a detached HEAD state. Check out a branch before releasing."
-    }
-
-    test("local release branch collision rolls back the local tag") {
-        // given: create release/app/v0.1.x locally but do NOT push it
-        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
-        project.createBranch("release/app/v0.1.x")
-        project.checkoutBranch("main")
-        project.createFakeBuiltArtifact()
-
-        // when: release tries to create release/app/v0.1.x locally → fails → tag rolled back
-        project.runTaskAndFail(":app:release")
-
-        // then: local tag was rolled back by Bug 2 fix
-        project.localTags() shouldNotContain "release/app/v0.1.0"
-    }
-
-    test("custom non-main primary branch with configured pattern creates release branch") {
-        // given: trunk is configured as the allowed release branch
-        val projectDir = testListener.getTestProjectDir()
-        val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
-
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                id("io.github.doug-hawley.monorepo-build-release-plugin")
-            }
-
-            monorepo {
-                release {
-                    releaseBranchPatterns = listOf("^trunk${'$'}")
-                }
-            }
-            """.trimIndent()
-        )
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            rootProject.name = "test-project"
-            include(":app")
-            """.trimIndent()
-        )
-        File(projectDir, ".gitignore").writeText(".gradle/\nbuild/")
-        val appDir = File(projectDir, "app")
-        appDir.mkdirs()
-        File(appDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                kotlin("jvm") version "2.0.21"
-            }
-            monorepoProject {
-                release {
-                    enabled = true
-                }
-            }
-            """.trimIndent()
-        )
-
-        remoteDir.mkdirs()
-        fun runGit(vararg cmd: String) {
-            val exitCode = ProcessBuilder(*cmd).directory(projectDir).start().waitFor()
-            if (exitCode != 0) throw RuntimeException("Command failed: ${cmd.joinToString(" ")}")
-        }
-        ProcessBuilder("git", "init", "--bare").directory(remoteDir).start().waitFor()
-        runGit("git", "init")
-        runGit("git", "config", "user.email", "test@example.com")
-        runGit("git", "config", "user.name", "Test User")
-        runGit("git", "checkout", "-b", "trunk")
-        runGit("git", "remote", "add", "origin", remoteDir.absolutePath)
-        runGit("git", "add", ".")
-        runGit("git", "commit", "-m", "Initial commit")
-        runGit("git", "push", "-u", "origin", "trunk")
-
-        val project = ReleaseTestProject(projectDir, remoteDir)
-        project.createFakeBuiltArtifact()
-
-        // when: on trunk (a non-release-branch primary branch) → should create release branch
-        val result = project.runTask(":app:release")
-
-        // then
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
 
     test("subproject with enabled=false has no release task") {
@@ -968,70 +807,10 @@ class ReleaseTaskFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
-    // Branch behavior
-    // ─────────────────────────────────────────────────────────────
-
-    test("non-main allowed branch creates release branch and pushes tag") {
-        // given: 'develop' added to releaseBranchPatterns; it is not a release branch,
-        // so the !isReleaseBranch path fires and a release branch is created
-        val projectDir = testListener.getTestProjectDir()
-        val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
-
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                id("io.github.doug-hawley.monorepo-build-release-plugin")
-            }
-            monorepo {
-                release {
-                    releaseBranchPatterns = listOf("^main${'$'}", "^develop${'$'}", "^release/.*")
-                }
-            }
-            """.trimIndent()
-        )
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            rootProject.name = "test-project"
-            include(":app")
-            """.trimIndent()
-        )
-        File(projectDir, ".gitignore").writeText(".gradle/\nbuild/")
-        val appDir = File(projectDir, "app")
-        appDir.mkdirs()
-        File(appDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                kotlin("jvm") version "2.0.21"
-            }
-            monorepoProject {
-                release {
-                    enabled = true
-                }
-            }
-            """.trimIndent()
-        )
-
-        val project = ReleaseTestProject(projectDir, remoteDir)
-        project.initGit()
-        project.commitAll("Initial commit")
-        project.pushToRemote()
-        project.createBranch("develop")
-        project.createFakeBuiltArtifact()
-
-        // when
-        val result = project.runTask(":app:release")
-
-        // then: tag and release branch both pushed (develop is a primary branch, not a release branch)
-        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteTags() shouldContain "release/app/v0.1.0"
-        project.remoteBranches() shouldContain "release/app/v0.1.x"
-    }
-
-    // ─────────────────────────────────────────────────────────────
     // Multi-project
     // ─────────────────────────────────────────────────────────────
 
-    test("multiple opted-in subprojects are versioned independently") {
+    test("multiple opted-in subprojects are versioned independently on their own release branches") {
         // given
         val projectDir = testListener.getTestProjectDir()
         val remoteDir = File(projectDir.parentFile, "${projectDir.name}-remote.git")
@@ -1073,16 +852,23 @@ class ReleaseTaskFunctionalTest : FunSpec({
         project.initGit()
         project.commitAll("Initial commit")
         project.pushToRemote()
+
+        // Release app from app's release branch
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
         File(projectDir, "app/build/libs").mkdirs()
         File(projectDir, "app/build/libs/app.jar").writeText("fake jar content")
+        project.runTask(":app:release")
+
+        // Switch to lib's release branch and release lib
+        project.checkoutBranch("main")
+        project.createBranch("release/lib/v0.1.x")
+        project.executeGitPush("release/lib/v0.1.x")
         File(projectDir, "lib/build/libs").mkdirs()
         File(projectDir, "lib/build/libs/lib.jar").writeText("fake jar content")
-
-        // when: release each subproject independently
-        project.runTask(":app:release")
         project.runTask(":lib:release")
 
-        // then: each has its own v0.1.0 tag, unaffected by the other
+        // then: each has its own v0.1.0 tag
         val tags = project.remoteTags()
         tags shouldContain "release/app/v0.1.0"
         tags shouldContain "release/lib/v0.1.0"

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolverTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolverTest.kt
@@ -5,47 +5,6 @@ import io.kotest.matchers.shouldBe
 
 class NextVersionResolverTest : FunSpec({
 
-    // ─────────────────────────────────────────────────────────────
-    // forPrimaryBranch
-    // ─────────────────────────────────────────────────────────────
-
-    test("forPrimaryBranch with no prior tags returns v0.1.0") {
-        // given
-        val latestVersion: SemanticVersion? = null
-
-        // when
-        val result = NextVersionResolver.forPrimaryBranch(latestVersion, Scope.MINOR)
-
-        // then
-        result shouldBe SemanticVersion(0, 1, 0)
-    }
-
-    test("forPrimaryBranch with existing tag bumps by scope") {
-        // given
-        val latestVersion = SemanticVersion(0, 1, 0)
-
-        // when
-        val result = NextVersionResolver.forPrimaryBranch(latestVersion, Scope.MINOR)
-
-        // then
-        result shouldBe SemanticVersion(0, 2, 0)
-    }
-
-    test("forPrimaryBranch with major scope bumps major") {
-        // given
-        val latestVersion = SemanticVersion(0, 3, 0)
-
-        // when
-        val result = NextVersionResolver.forPrimaryBranch(latestVersion, Scope.MAJOR)
-
-        // then
-        result shouldBe SemanticVersion(1, 0, 0)
-    }
-
-    // ─────────────────────────────────────────────────────────────
-    // forReleaseBranch
-    // ─────────────────────────────────────────────────────────────
-
     test("forReleaseBranch with no prior tags in version line returns major.minor.0") {
         // given — on release branch v0.2.x with no v0.2.* tags
         val latestInLine: SemanticVersion? = null

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/TagPatternTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/TagPatternTest.kt
@@ -110,4 +110,14 @@ class TagPatternTest : FunSpec({
             exception.message shouldContain branch
         }
     }
+
+    context("parseProjectPrefixFromBranch extracts the project prefix") {
+        withData(
+            Triple("release/app/v0.1.x", "release", "app"),
+            Triple("release/services-auth/v1.2.x", "release", "services-auth"),
+            Triple("deploy/my-app/v0.3.x", "deploy", "my-app"),
+        ) { (branch, globalPrefix, expectedPrefix) ->
+            TagPattern.parseProjectPrefixFromBranch(branch, globalPrefix) shouldBe expectedPrefix
+        }
+    }
 })


### PR DESCRIPTION
## Summary

- Release task now **requires** execution from a release branch matching the project being released
- Releases from `main`, feature branches, or mismatched release branches fail with clear error messages
- Removes the primary branch release path from `ReleaseTask` (branch creation from main is handled by `CreateReleaseBranchTask`)
- Adds `TagPattern.parseProjectPrefixFromBranch()` for branch-to-project validation
- Removes `NextVersionResolver.forPrimaryBranch()` (no longer needed)
- Updates README to reflect the release branch requirement

## Test plan

- [x] All existing unit tests pass
- [x] All existing integration tests pass
- [x] All functional tests rewritten to release from release branches
- [x] New test: release from `main` fails with descriptive error
- [x] New test: release from wrong project's release branch fails with descriptive error
- [x] Multi-project test validates each project releases from its own branch
- [x] `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)