### PR TITLE
feat: add atomic release branch creation task

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -9,6 +9,9 @@ import io.github.doughawley.monorepo.build.git.GitRepository
 import io.github.doughawley.monorepo.build.task.PrintChangedProjectsTask
 import io.github.doughawley.monorepo.release.MonorepoReleaseConfigExtension
 import io.github.doughawley.monorepo.release.MonorepoReleaseExtension
+import io.github.doughawley.monorepo.release.domain.Scope
+import io.github.doughawley.monorepo.release.domain.TagPattern
+import io.github.doughawley.monorepo.release.git.AtomicReleaseBranchCreator
 import io.github.doughawley.monorepo.release.task.ReleaseTask
 import io.github.doughawley.monorepo.git.GitCommandExecutor
 import io.github.doughawley.monorepo.release.git.GitReleaseExecutor
@@ -77,6 +80,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                     rootBuildExtension.resolvedBaseRef = resolvedRef
                     computeMetadata(project.rootProject, rootBuildExtension, resolvedRef)
                     wireDependsOn(project, "buildChangedProjects", rootBuildExtension.allAffectedProjects)
+                    wireDependsOn(project, "buildChangedProjectsAndCreateReleaseBranches", rootBuildExtension.allAffectedProjects)
                     rootBuildExtension.metadataComputed = true
                     project.logger.debug("Changed project metadata computed successfully in configuration phase")
                 } catch (e: GradleException) {
@@ -116,6 +120,69 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                 } else {
                     project.logger.lifecycle("Building changed projects: ${changedProjects.joinToString(", ")}")
                 }
+            }
+        }
+
+        // ── Aggregate release task ────────────────────────────────────────────
+
+        project.tasks.register("buildChangedProjectsAndCreateReleaseBranches").configure {
+            group = RELEASE_TASK_GROUP
+            description = "Builds changed projects and creates release branches atomically"
+            doLast {
+                val ext = project.rootProject.extensions.getByType(MonorepoExtension::class.java)
+                val buildExt = ext.build
+                val releaseExt = ext.release
+
+                if (!buildExt.metadataComputed) {
+                    throw IllegalStateException(
+                        "Changed project metadata was not computed in the configuration phase."
+                    )
+                }
+
+                // Branch guard: must be on primaryBranch
+                val executor = GitCommandExecutor(project.logger)
+                val releaseExecutor = GitReleaseExecutor(project.rootProject.rootDir, executor, project.logger)
+                val currentBranch = releaseExecutor.currentBranch()
+                if (currentBranch != ext.primaryBranch) {
+                    throw GradleException(
+                        "buildChangedProjectsAndCreateReleaseBranches must run on '${ext.primaryBranch}', " +
+                        "but the current branch is '$currentBranch'."
+                    )
+                }
+
+                // Collect opted-in changed projects
+                val changedProjects = buildExt.allAffectedProjects
+                val optedInProjects = changedProjects.mapNotNull { projectPath ->
+                    val targetProject = project.rootProject.findProject(projectPath) ?: return@mapNotNull null
+                    val projectExt = targetProject.extensions.findByType(MonorepoProjectExtension::class.java)
+                        ?: return@mapNotNull null
+                    if (!projectExt.release.enabled) return@mapNotNull null
+                    val tagPrefix = projectExt.release.tagPrefix
+                        ?: TagPattern.deriveProjectTagPrefix(projectPath)
+                    projectPath to tagPrefix
+                }.toMap()
+
+                if (optedInProjects.isEmpty()) {
+                    project.logger.lifecycle("No opted-in changed projects — no release branches to create")
+                    return@doLast
+                }
+
+                // Resolve scope
+                val scope = Scope.fromString(releaseExt.primaryBranchScope)
+                    ?: throw GradleException(
+                        "Invalid primaryBranchScope: '${releaseExt.primaryBranchScope}'. " +
+                        "Must be one of: major, minor"
+                    )
+                if (scope == Scope.PATCH) {
+                    throw GradleException(
+                        "Cannot use primaryBranchScope 'patch'. Use 'minor' or 'major'."
+                    )
+                }
+
+                // Atomic branch creation
+                val tagScanner = GitTagScanner(project.rootProject.rootDir, executor)
+                val branchCreator = AtomicReleaseBranchCreator(releaseExecutor, tagScanner, project.logger)
+                branchCreator.createReleaseBranches(optedInProjects, releaseExt.globalTagPrefix, scope)
             }
         }
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/AtomicReleaseBranchCreator.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/AtomicReleaseBranchCreator.kt
@@ -1,0 +1,106 @@
+package io.github.doughawley.monorepo.release.git
+
+import io.github.doughawley.monorepo.release.domain.Scope
+import io.github.doughawley.monorepo.release.domain.SemanticVersion
+import io.github.doughawley.monorepo.release.domain.TagPattern
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+
+/**
+ * Two-phase atomic release branch creation.
+ *
+ * Phase 1: Create all release branches locally. If any local creation fails,
+ *          roll back all previously created branches and fail.
+ * Phase 2: Push all branches atomically with `git push --atomic`.
+ *          If the push fails, delete all local branches and fail.
+ */
+class AtomicReleaseBranchCreator(
+    private val gitReleaseExecutor: GitReleaseExecutor,
+    private val gitTagScanner: GitTagScanner,
+    private val logger: Logger
+) {
+
+    data class ReleaseBranchResult(
+        val createdBranches: List<String>,
+        val projectToBranch: Map<String, String>
+    )
+
+    /**
+     * Creates release branches for the given projects atomically.
+     *
+     * @param projects map of Gradle project path to its resolved tag prefix
+     * @param globalPrefix the global tag prefix (e.g., "release")
+     * @param scope the version bump scope (major or minor)
+     * @return the result containing created branch names
+     * @throws GradleException if any phase fails (all local branches are rolled back)
+     */
+    fun createReleaseBranches(
+        projects: Map<String, String>,
+        globalPrefix: String,
+        scope: Scope
+    ): ReleaseBranchResult {
+        if (projects.isEmpty()) {
+            logger.lifecycle("No opted-in changed projects — no release branches to create")
+            return ReleaseBranchResult(emptyList(), emptyMap())
+        }
+
+        val projectToBranch = resolveReleaseBranches(projects, globalPrefix, scope)
+        val branchNames = projectToBranch.values.toList()
+
+        // Phase 1: Create all branches locally
+        val createdBranches = mutableListOf<String>()
+        try {
+            for (branch in branchNames) {
+                if (gitReleaseExecutor.branchExistsLocally(branch)) {
+                    throw GradleException(
+                        "Release branch '$branch' already exists locally. " +
+                        "Delete it manually or skip this project."
+                    )
+                }
+                gitReleaseExecutor.createBranchLocally(branch)
+                createdBranches.add(branch)
+            }
+        } catch (e: Exception) {
+            logger.error("Local branch creation failed, rolling back ${createdBranches.size} branch(es): ${e.message}")
+            rollbackLocalBranches(createdBranches)
+            throw GradleException("Failed to create release branches locally: ${e.message}", e)
+        }
+
+        // Phase 2: Push all branches atomically
+        try {
+            gitReleaseExecutor.pushBranchesAtomically(branchNames)
+        } catch (e: Exception) {
+            logger.error("Atomic push failed, rolling back ${createdBranches.size} local branch(es): ${e.message}")
+            rollbackLocalBranches(createdBranches)
+            throw GradleException("Atomic push of release branches failed: ${e.message}", e)
+        }
+
+        projectToBranch.forEach { (projectPath, branch) ->
+            logger.lifecycle("Created release branch '$branch' for $projectPath")
+        }
+
+        return ReleaseBranchResult(branchNames, projectToBranch)
+    }
+
+    private fun resolveReleaseBranches(
+        projects: Map<String, String>,
+        globalPrefix: String,
+        scope: Scope
+    ): Map<String, String> {
+        return projects.mapValues { (_, projectPrefix) ->
+            val latestVersion = gitTagScanner.findLatestVersion(globalPrefix, projectPrefix)
+            val nextVersion = if (latestVersion == null) {
+                SemanticVersion(0, 1, 0)
+            } else {
+                latestVersion.bump(scope)
+            }
+            TagPattern.formatReleaseBranch(globalPrefix, projectPrefix, nextVersion)
+        }
+    }
+
+    private fun rollbackLocalBranches(branches: List<String>) {
+        branches.forEach { branch ->
+            gitReleaseExecutor.deleteLocalBranch(branch)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
@@ -76,4 +76,21 @@ class GitReleaseExecutor(
             logger.lifecycle("Deleted local branch: $branch")
         }
     }
+
+    fun pushBranchesAtomically(branches: List<String>) {
+        val args = mutableListOf("push", "--atomic", "origin")
+        args.addAll(branches)
+        val result = executor.execute(rootDir, *args.toTypedArray())
+        if (!result.success) {
+            throw GradleException(
+                "Atomic push of ${branches.size} branch(es) failed: ${result.errorOutput}"
+            )
+        }
+        logger.lifecycle("Pushed ${branches.size} branch(es) atomically to remote")
+    }
+
+    fun branchExistsLocally(branch: String): Boolean {
+        val result = executor.execute(rootDir, "rev-parse", "--verify", "refs/heads/$branch")
+        return result.success
+    }
 }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
@@ -1,0 +1,209 @@
+package io.github.doughawley.monorepo.release.functional
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+
+class BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest : FunSpec({
+
+    val testListener = listener(ReleaseTestProjectListener())
+
+    // ─────────────────────────────────────────────────────────────
+    // Branch guard
+    // ─────────────────────────────────────────────────────────────
+
+    test("fails fast when not on primaryBranch") {
+        // given
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.modifyFile("app/app.txt", "changed")
+        project.commitAll("Change app")
+        project.createBranch("feature/something")
+
+        // when
+        val result = project.runTaskAndFail("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.output shouldContain "must run on 'main'"
+        result.output shouldContain "current branch is 'feature/something'"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // No changed projects
+    // ─────────────────────────────────────────────────────────────
+
+    test("succeeds with no branches created when no projects have changed") {
+        // given: tag at HEAD so no changes detected
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.createTag("monorepo/last-successful-build")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Single project changed
+    // ─────────────────────────────────────────────────────────────
+
+    test("creates release branch only for the changed opted-in project") {
+        // given
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.createTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.commitAll("Change app")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+        project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Both projects changed
+    // ─────────────────────────────────────────────────────────────
+
+    test("creates release branches for all changed opted-in projects") {
+        // given
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.createTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.modifyFile("lib/lib.txt", "changed")
+        project.commitAll("Change both")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+        project.remoteBranches() shouldContain "release/lib/v0.1.x"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Opt-in model
+    // ─────────────────────────────────────────────────────────────
+
+    test("skips project with enabled=false even when it has changed") {
+        // given: lib has enabled=false
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(
+            testListener.getTestProjectDir(),
+            libEnabled = false
+        )
+        project.createTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.modifyFile("lib/lib.txt", "changed")
+        project.commitAll("Change both")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+        project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Scope override
+    // ─────────────────────────────────────────────────────────────
+
+    test("primaryBranchScope=major creates v1.0.x branches when prior v0.x.x tags exist") {
+        // given
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(
+            testListener.getTestProjectDir(),
+            primaryBranchScope = "major"
+        )
+        project.createTag("release/app/v0.1.0")
+        project.pushTag("release/app/v0.1.0")
+        project.createTag("release/lib/v0.1.0")
+        project.pushTag("release/lib/v0.1.0")
+        project.createTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.modifyFile("lib/lib.txt", "changed")
+        project.commitAll("Change both")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v1.0.x"
+        project.remoteBranches() shouldContain "release/lib/v1.0.x"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Rollback on local branch collision
+    // ─────────────────────────────────────────────────────────────
+
+    test("rolls back all local branches when one already exists locally") {
+        // given: pre-create a local branch for app so creation fails
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.createTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.modifyFile("lib/lib.txt", "changed")
+        project.commitAll("Change both")
+        project.createBranch("release/app/v0.1.x")
+        project.checkoutBranch("main")
+
+        // when
+        val result = project.runTaskAndFail("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then: task fails; neither branch pushed to remote
+        result.output shouldContain "already exists locally"
+        project.remoteBranches() shouldNotContain "release/app/v0.1.x"
+        project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // All disabled
+    // ─────────────────────────────────────────────────────────────
+
+    test("no release branches created when all changed projects have release disabled") {
+        // given: both disabled
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(
+            testListener.getTestProjectDir(),
+            libEnabled = false
+        )
+        // Override app to also be disabled
+        val appBuild = java.io.File(project.projectDir, "app/build.gradle.kts")
+        appBuild.writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = false
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.commitAll("Disable app release")
+        project.createTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.modifyFile("lib/lib.txt", "changed")
+        project.commitAll("Change both")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "no release branches to create"
+        project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
+    }
+})

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/BuildChangedProjectsTaskTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/BuildChangedProjectsTaskTest.kt
@@ -20,4 +20,18 @@ class BuildChangedProjectsTaskTest : FunSpec({
         task?.group shouldBe "monorepo"
         task?.description shouldBe "Builds only the projects that have been affected by changes"
     }
+
+    test("buildChangedProjectsAndCreateReleaseBranches task should be registered") {
+        // given
+        val project = ProjectBuilder.builder().build()
+
+        // when
+        project.pluginManager.apply("io.github.doug-hawley.monorepo-build-release-plugin")
+
+        // then
+        val task = project.tasks.findByName("buildChangedProjectsAndCreateReleaseBranches")
+        task shouldNotBe null
+        task?.group shouldBe "monorepo-release"
+        task?.description shouldBe "Builds changed projects and creates release branches atomically"
+    }
 })


### PR DESCRIPTION
## Summary

- Adds `buildChangedProjectsAndCreateReleaseBranches` aggregator task for CI post-merge workflows
- Introduces `AtomicReleaseBranchCreator` service with two-phase branch creation: create all locally, then `git push --atomic` — rolls back on any failure
- Task includes branch guard (must be on `primaryBranch`) and respects per-project release opt-in model
- Adds `pushBranchesAtomically()` and `branchExistsLocally()` to `GitReleaseExecutor`

## PR 2 of 5

Part of the unified change detection plan tracked in #97. Depends on #98 (merged).

## Test plan

- [x] All tests pass (310 total, 0 failures)
- [x] Branch guard: fails fast when not on primaryBranch
- [x] No changes: succeeds with no branches created
- [x] Single project changed: creates branch only for opted-in project
- [x] Both projects changed: creates branches for all opted-in projects
- [x] Opt-in model: skips projects with `enabled = false`
- [x] Scope override: `primaryBranchScope = "major"` creates correct version line
- [x] Rollback: rolls back all local branches when one already exists
- [x] All disabled: logs message and creates no branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)