### PR TITLE
docs: fix stale references to removed tasks and DSL properties

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,9 +31,11 @@ assignees: ''
 
 ```kotlin
 // Your plugin configuration
-monorepoBuild {
-    baseBranch = "main"
-    // ...
+monorepo {
+    primaryBranch = "main"
+    build {
+        // ...
+    }
 }
 ```
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,7 +23,7 @@ assignees: ''
 
 ```kotlin
 // Example usage
-monorepoBuild {
+monorepo {
     // Your proposed API
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,13 +142,14 @@ This project follows [Kotlin coding conventions](https://kotlinlang.org/docs/cod
 Example:
 ```kotlin
 /**
- * Detects changed files by comparing against a base branch.
+ * Detects changed files by comparing HEAD against a resolved base ref.
  *
- * @param baseBranch The branch to compare against (e.g., "main", "develop")
+ * @param resolvedBaseRef The ref to compare against (tag or origin/branch)
  * @param includeUntracked Whether to include untracked files in the detection
- * @return List of file paths that have changed
+ * @param excludePatterns Regex patterns for files to exclude
+ * @return Set of file paths that have changed
  */
-fun detectChangedFiles(baseBranch: String, includeUntracked: Boolean): List<String>
+fun getChangedFiles(resolvedBaseRef: String, includeUntracked: Boolean, excludePatterns: List<String>): Set<String>
 ```
 
 ## Commit Guidelines
@@ -339,7 +340,7 @@ mkdir test-project
 cd test-project
 git init
 # Create build.gradle.kts with your plugin
-./gradlew printChangedProjectsFromBranch
+./gradlew printChangedProjects
 ```
 
 ### Debugging
@@ -347,7 +348,7 @@ git init
 Run Gradle with debug logging:
 
 ```bash
-./gradlew printChangedProjectsFromBranch --debug
+./gradlew printChangedProjects --debug
 ```
 
 Run tests with IntelliJ IDEA debugger:

--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -188,14 +188,16 @@ plugins {
     id("io.github.doug-hawley.monorepo-build-release-plugin") version "0.3.2"
 }
 
-monorepoBuild {
-    baseBranch = "main"
-    includeUntracked = true
+monorepo {
+    primaryBranch = "main"
+    build {
+        includeUntracked = true
+    }
 }
 ```
 
 ```bash
-./gradlew printChangedProjectsFromBranch
+./gradlew printChangedProjects
 ```
 
 ### Update Badges (Optional)

--- a/TEST_STRUCTURE.md
+++ b/TEST_STRUCTURE.md
@@ -46,12 +46,13 @@ Functional tests verify end-to-end functionality:
 - Tests real-world scenarios with actual git operations
 
 **Current Functional Tests:**
-- `MonorepoPluginDetectionFunctionalTest.kt` - Tests the `printChangedProjectsFromBranch` task
-- `BuildChangedProjectsFunctionalTest.kt` - Tests the `buildChangedProjectsFromBranch` task
+- `PrintChangedProjectsFunctionalTest.kt` - Tests the `printChangedProjects` task
+- `BuildChangedProjectsFunctionalTest.kt` - Tests the `buildChangedProjects` task
 - `MonorepoPluginConfigurationTest.kt` - Configuration and exclude pattern scenarios
-- `PrintChangedProjectsFromRefFunctionalTest.kt` - Tests the ref-mode task
-- `ReleaseChangedProjectsFunctionalTest.kt` - Tests the `releaseChangedProjects` task
-- `ReleaseTaskFunctionalTest.kt` - Release task edge cases
+- `MonorepoPluginHierarchyNodeFunctionalTest.kt` - Hierarchy node detection
+- `MonorepoPluginNestedProjectFunctionalTest.kt` - Nested project detection
+- `ReleaseTaskFunctionalTest.kt` - Per-subproject `release` task
+- `BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt` - Aggregator task with atomic branch creation
 
 **Test Utilities:**
 - `TestProjectBuilder.kt` - Helper for creating test Gradle projects


### PR DESCRIPTION
## Summary

Fixes stale references found during post-merge review of the unified change detection refactor.

- **CONTRIBUTING.md**: Updated task names and code example
- **TEST_STRUCTURE.md**: Updated functional test file listing
- **PUBLISHING_GUIDE.md**: Updated DSL example and task name
- **Bug report template**: Updated DSL example
- **Feature request template**: Updated DSL example

`CODE_REVIEW.md` references were left as-is since they're historical records of past fixes.

## Test plan

- [x] Documentation-only changes, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)