### PR TITLE
test: add missing integration and functional test coverage

### DIFF
--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFunctionalTest.kt
@@ -254,4 +254,48 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "No projects have changed - nothing to build"
     }
+
+    test("buildChangedProjects falls back to origin/main when tag does not exist") {
+        // given: project with remote but no last-successful-build tag
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+        project.appendToFile(Files.APP1_SOURCE, "\n// Modified")
+        project.commitAll("Change app1")
+
+        // when
+        val result = project.runTask("buildChangedProjects")
+
+        // then: falls back to origin/main, detects the change
+        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        val built = result.extractBuiltProjects()
+        built shouldContain Projects.APP1
+    }
+
+    test("buildChangedProjects does not update the last-successful-build tag") {
+        // given: create a tag, make a change, run buildChangedProjects
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+        project.executeGitCommand("tag", "monorepo/last-successful-build")
+        project.executeGitCommand("push", "origin", "monorepo/last-successful-build")
+        val tagCommitBefore = project.getLastCommitSha()
+
+        project.appendToFile(Files.APP2_SOURCE, "\n// Modified")
+        project.commitAll("Change app2")
+
+        // when
+        val result = project.runTask("buildChangedProjects")
+
+        // then: tag should still point at the original commit
+        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        val built = result.extractBuiltProjects()
+        built shouldContain Projects.APP2
+
+        // Verify tag was NOT moved by checking it still resolves to the original commit
+        val tagCommitAfter = project.getLastCommitSha("monorepo/last-successful-build")
+        tagCommitAfter shouldBe tagCommitBefore
+    }
 })

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
@@ -267,8 +267,8 @@ class TestProject(
         executeCommand("git", *args)
     }
 
-    fun getLastCommitSha(): String {
-        val process = ProcessBuilder("git", "rev-parse", "HEAD")
+    fun getLastCommitSha(ref: String = "HEAD"): String {
+        val process = ProcessBuilder("git", "rev-parse", ref)
             .directory(projectDir)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .start()

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectListener.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectListener.kt
@@ -59,7 +59,7 @@ class TestProjectListener : TestListener {
 
     override suspend fun beforeEach(testCase: TestCase) {
         // Sanitize test name for use in file paths (Windows doesn't allow : < > " | ? *)
-        val sanitizedTestName = testCase.name.testName.replace(Regex("[:<>\"|?*]"), "-")
+        val sanitizedTestName = testCase.name.testName.replace(Regex("[:<>\"|?*/]"), "-")
         val tempDir = kotlin.io.path.createTempDirectory("monorepo-test-$sanitizedTestName").toFile()
         currentTestDir = tempDir
     }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
@@ -176,6 +176,63 @@ class BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest : FunSpec({
     // All disabled
     // ─────────────────────────────────────────────────────────────
 
+    test("does not update tag when a subproject build fails") {
+        // given: app's build task will throw an error
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        val appBuild = java.io.File(project.projectDir, "app/build.gradle.kts")
+        appBuild.writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = true
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    throw GradleException("Simulated build failure")
+                }
+            }
+            """.trimIndent()
+        )
+        project.commitAll("Make app build fail")
+        project.createTag("monorepo/last-successful-build")
+        project.pushTag("monorepo/last-successful-build")
+        val tagCommitBefore = project.commitForTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.commitAll("Change app")
+
+        // when
+        val result = project.runTaskAndFail("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then: tag should NOT have moved
+        result.output shouldContain "Simulated build failure"
+        project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
+        project.remoteTagCommit("monorepo/last-successful-build") shouldBe tagCommitBefore
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fallback to origin/main when tag does not exist
+    // ─────────────────────────────────────────────────────────────
+
+    test("falls back to origin/main when last-successful-build tag does not exist") {
+        // given: no tag, so plugin should fallback to origin/main
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.modifyFile("app/app.txt", "changed")
+        project.commitAll("Change app")
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then: should detect changes and create release branch
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // All disabled
+    // ─────────────────────────────────────────────────────────────
+
     test("updates tag but creates no branches when all changed projects have release disabled") {
         // given: both disabled
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/build/git/LastSuccessfulBuildTagUpdaterIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/build/git/LastSuccessfulBuildTagUpdaterIntegrationTest.kt
@@ -1,0 +1,63 @@
+package io.github.doughawley.monorepo.build.git
+
+import io.github.doughawley.monorepo.git.GitCommandExecutor
+import io.github.doughawley.monorepo.release.git.TempGitRepo
+import io.github.doughawley.monorepo.release.git.TempGitRepoListener
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+import org.gradle.api.logging.Logger
+
+class LastSuccessfulBuildTagUpdaterIntegrationTest : FunSpec({
+
+    val repoListener = TempGitRepoListener()
+    listener(repoListener)
+
+    val logger = mockk<Logger>(relaxed = true)
+
+    fun createUpdater(): LastSuccessfulBuildTagUpdater {
+        val executor = GitCommandExecutor(logger)
+        return LastSuccessfulBuildTagUpdater(repoListener.repo.localDir, executor, logger)
+    }
+
+    test("creates tag locally and pushes it to remote") {
+        // given
+        val updater = createUpdater()
+
+        // when
+        updater.updateTag("monorepo/last-successful-build")
+
+        // then
+        repoListener.repo.localTagExists("monorepo/last-successful-build") shouldBe true
+        repoListener.repo.remoteTagExists("monorepo/last-successful-build") shouldBe true
+    }
+
+    test("force-updates existing tag to HEAD after new commit") {
+        // given: create initial tag, then make a new commit
+        val updater = createUpdater()
+        updater.updateTag("monorepo/last-successful-build")
+        repoListener.repo.modifyTrackedFile("README.md", "new content")
+        repoListener.repo.commitAll("second commit")
+
+        // when
+        updater.updateTag("monorepo/last-successful-build")
+
+        // then: tag should point at the new HEAD, not the old commit
+        repoListener.repo.localTagExists("monorepo/last-successful-build") shouldBe true
+        repoListener.repo.remoteTagExists("monorepo/last-successful-build") shouldBe true
+    }
+
+    test("works with slash-delimited tag names") {
+        // given
+        val updater = createUpdater()
+
+        // when
+        updater.updateTag("custom/prefix/last-build")
+
+        // then
+        repoListener.repo.localTagExists("custom/prefix/last-build") shouldBe true
+        repoListener.repo.remoteTagExists("custom/prefix/last-build") shouldBe true
+    }
+})

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/AtomicReleaseBranchCreatorIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/AtomicReleaseBranchCreatorIntegrationTest.kt
@@ -1,0 +1,111 @@
+package io.github.doughawley.monorepo.release.git
+
+import io.github.doughawley.monorepo.git.GitCommandExecutor
+import io.github.doughawley.monorepo.release.domain.Scope
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+
+class AtomicReleaseBranchCreatorIntegrationTest : FunSpec({
+
+    val repoListener = TempGitRepoListener()
+    listener(repoListener)
+
+    val logger = mockk<Logger>(relaxed = true)
+
+    fun createCreator(): AtomicReleaseBranchCreator {
+        val executor = GitCommandExecutor(logger)
+        val releaseExecutor = GitReleaseExecutor(repoListener.repo.localDir, executor, logger)
+        val tagScanner = GitTagScanner(repoListener.repo.localDir, executor)
+        return AtomicReleaseBranchCreator(releaseExecutor, tagScanner, logger)
+    }
+
+    test("creates release branches for multiple projects and pushes them atomically") {
+        // given
+        val creator = createCreator()
+        val projects = mapOf(
+            ":app" to "app",
+            ":lib" to "lib"
+        )
+
+        // when
+        val result = creator.createReleaseBranches(projects, "release", Scope.MINOR)
+
+        // then
+        result.createdBranches shouldContainExactlyInAnyOrder listOf("release/app/v0.1.x", "release/lib/v0.1.x")
+        result.projectToBranch[":app"] shouldBe "release/app/v0.1.x"
+        result.projectToBranch[":lib"] shouldBe "release/lib/v0.1.x"
+        repoListener.repo.remoteBranchExists("release/app/v0.1.x") shouldBe true
+        repoListener.repo.remoteBranchExists("release/lib/v0.1.x") shouldBe true
+    }
+
+    test("returns empty result when project map is empty") {
+        // given
+        val creator = createCreator()
+
+        // when
+        val result = creator.createReleaseBranches(emptyMap(), "release", Scope.MINOR)
+
+        // then
+        result.createdBranches.shouldBeEmpty()
+        result.projectToBranch.shouldBeEmpty()
+    }
+
+    test("bumps version based on existing tags") {
+        // given: app already has v0.1.0
+        repoListener.repo.pushTag("release/app/v0.1.0")
+        val creator = createCreator()
+        val projects = mapOf(":app" to "app")
+
+        // when
+        val result = creator.createReleaseBranches(projects, "release", Scope.MINOR)
+
+        // then: next minor is v0.2.x
+        result.createdBranches shouldContainExactlyInAnyOrder listOf("release/app/v0.2.x")
+        repoListener.repo.remoteBranchExists("release/app/v0.2.x") shouldBe true
+    }
+
+    test("uses major scope when requested") {
+        // given: app already has v0.1.0
+        repoListener.repo.pushTag("release/app/v0.1.0")
+        val creator = createCreator()
+        val projects = mapOf(":app" to "app")
+
+        // when
+        val result = creator.createReleaseBranches(projects, "release", Scope.MAJOR)
+
+        // then: major bump → v1.0.x
+        result.createdBranches shouldContainExactlyInAnyOrder listOf("release/app/v1.0.x")
+        repoListener.repo.remoteBranchExists("release/app/v1.0.x") shouldBe true
+    }
+
+    test("rolls back all local branches when one already exists locally") {
+        // given: pre-create a branch for lib
+        val executor = GitCommandExecutor(logger)
+        val releaseExecutor = GitReleaseExecutor(repoListener.repo.localDir, executor, logger)
+        releaseExecutor.createBranchLocally("release/lib/v0.1.x")
+
+        val creator = createCreator()
+        val projects = mapOf(
+            ":app" to "app",
+            ":lib" to "lib"
+        )
+
+        // when / then
+        val ex = shouldThrow<GradleException> {
+            creator.createReleaseBranches(projects, "release", Scope.MINOR)
+        }
+        ex.message shouldContain "already exists locally"
+
+        // neither branch pushed to remote
+        repoListener.repo.remoteBranchExists("release/app/v0.1.x") shouldBe false
+        repoListener.repo.remoteBranchExists("release/lib/v0.1.x") shouldBe false
+    }
+})

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutorIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutorIntegrationTest.kt
@@ -236,4 +236,63 @@ class GitReleaseExecutorIntegrationTest : FunSpec({
         // given / when / then — no exception
         executor().deleteLocalBranch("release/app/v9.9.x")
     }
+
+    // branchExistsLocally
+
+    test("branchExistsLocally returns true for a branch that exists") {
+        // given
+        executor().createBranchLocally("release/app/v1.0.x")
+
+        // when / then
+        executor().branchExistsLocally("release/app/v1.0.x") shouldBe true
+    }
+
+    test("branchExistsLocally returns false for a branch that does not exist") {
+        // given / when / then
+        executor().branchExistsLocally("release/nonexistent/v9.9.x") shouldBe false
+    }
+
+    test("branchExistsLocally returns false after a branch is deleted") {
+        // given
+        executor().createBranchLocally("release/app/v1.0.x")
+        executor().deleteLocalBranch("release/app/v1.0.x")
+
+        // when / then
+        executor().branchExistsLocally("release/app/v1.0.x") shouldBe false
+    }
+
+    // pushBranchesAtomically
+
+    test("pushBranchesAtomically pushes all branches to remote in one operation") {
+        // given
+        executor().createBranchLocally("release/app/v1.0.x")
+        executor().createBranchLocally("release/lib/v2.0.x")
+
+        // when
+        executor().pushBranchesAtomically(listOf("release/app/v1.0.x", "release/lib/v2.0.x"))
+
+        // then
+        repoListener.repo.remoteBranchExists("release/app/v1.0.x") shouldBe true
+        repoListener.repo.remoteBranchExists("release/lib/v2.0.x") shouldBe true
+    }
+
+    test("pushBranchesAtomically pushes a single branch") {
+        // given
+        executor().createBranchLocally("release/app/v1.0.x")
+
+        // when
+        executor().pushBranchesAtomically(listOf("release/app/v1.0.x"))
+
+        // then
+        repoListener.repo.remoteBranchExists("release/app/v1.0.x") shouldBe true
+    }
+
+    test("pushBranchesAtomically throws when a branch does not exist locally") {
+        // given / when / then
+        val ex = shouldThrow<GradleException> {
+            executor().pushBranchesAtomically(listOf("release/nonexistent/v1.0.x"))
+        }
+        ex.message shouldContain "Atomic push"
+        ex.message shouldContain "failed"
+    }
 })


### PR DESCRIPTION
## Summary
- **Integration tests**: `LastSuccessfulBuildTagUpdater` (3 tests), `AtomicReleaseBranchCreator` (5 tests), `GitReleaseExecutor` new methods `branchExistsLocally` and `pushBranchesAtomically` (6 tests)
- **Functional tests**: fallback to `origin/main` when tag doesn't exist, `buildChangedProjects` never updates tag, build failure doesn't update tag, fallback in release task
- **Bug fix**: `TestProjectListener` now sanitizes `/` in test names (matching `ReleaseTestProjectListener`)

## Test plan
- [x] `./gradlew check` passes (unit + integration + functional)
- [x] All new tests verified green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)