### PR TITLE
Remove dead code and add edge case tests

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
@@ -23,15 +23,6 @@ open class GitRepository(
     open fun isRepository(): Boolean = gitDir != null
 
     /**
-     * Three-dot diff against a resolved base ref.
-     * Returns files changed between the merge-base of [resolvedRef] and HEAD.
-     */
-    open fun diffBranch(resolvedRef: String): List<String> {
-        val dir = gitDir ?: return emptyList()
-        return gitExecutor.executeForOutput(dir, "diff", "--name-only", "$resolvedRef...HEAD")
-    }
-
-    /**
      * Two-dot diff against a specific commit ref.
      * Returns files changed between [commitRef] and HEAD.
      *

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutorIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutorIntegrationTest.kt
@@ -287,6 +287,14 @@ class GitReleaseExecutorIntegrationTest : FunSpec({
         repoListener.repo.remoteBranchExists("release/app/v1.0.x") shouldBe true
     }
 
+    test("pushBranchesAtomically with empty list succeeds without pushing any branches") {
+        // given / when — empty list results in `git push --atomic origin` with no refspecs
+        executor().pushBranchesAtomically(emptyList())
+
+        // then — no branches were pushed to remote (only the default branch exists)
+        repoListener.repo.remoteBranchExists("release/app/v1.0.x") shouldBe false
+    }
+
     test("pushBranchesAtomically throws when a branch does not exist locally") {
         // given / when / then
         val ex = shouldThrow<GradleException> {

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/ChangedProjectsPrinterTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/ChangedProjectsPrinterTest.kt
@@ -93,6 +93,36 @@ class ChangedProjectsPrinterTest : FunSpec({
         result shouldContain ": (root)"
     }
 
+    test("lists transitively affected project with multiple via annotations") {
+        // given
+        val apiMetadata = ProjectMetadata(
+            name = "api",
+            fullyQualifiedName = ":api",
+            changedFiles = listOf("api/src/main/kotlin/Api.kt")
+        )
+        val coreMetadata = ProjectMetadata(
+            name = "core",
+            fullyQualifiedName = ":core",
+            changedFiles = listOf("core/src/main/kotlin/Core.kt")
+        )
+        val appMetadata = ProjectMetadata(
+            name = "app",
+            fullyQualifiedName = ":app",
+            dependencies = listOf(apiMetadata, coreMetadata)
+        )
+        val printer = ChangedProjectsPrinter()
+
+        // when
+        val result = printer.buildReport(
+            header = "Changed projects:",
+            monorepoProjects = MonorepoProjects(listOf(apiMetadata, coreMetadata, appMetadata))
+        )
+
+        // then
+        result shouldContain ":app"
+        result shouldContain "affected via :api, :core"
+    }
+
     test("multiple directly changed projects are listed sorted") {
         // given
         val printer = ChangedProjectsPrinter()

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
@@ -53,33 +53,6 @@ class GitRepositoryTest : FunSpec({
         }
     }
 
-    // --- diffBranch ---
-
-    test("diffBranch returns files changed since the base ref") {
-        // given — create a branch at the initial commit, then add a new file on the current branch
-        git(repoDir, "branch", "base")
-        File(repoDir, "added.kt").writeText("new code")
-        git(repoDir, "add", "added.kt")
-        git(repoDir, "commit", "-m", "add file")
-
-        // when
-        val result = GitRepository(repoDir, logger).diffBranch("base")
-
-        // then
-        result shouldContain "added.kt"
-    }
-
-    test("diffBranch returns empty list when nothing has changed since the base ref") {
-        // given — branch points at HEAD, nothing new committed
-        git(repoDir, "branch", "base")
-
-        // when
-        val result = GitRepository(repoDir, logger).diffBranch("base")
-
-        // then
-        result.shouldBeEmpty()
-    }
-
     // --- diffFromRef ---
 
     test("diffFromRef returns files changed since the given commit ref") {

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/TagPatternTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/TagPatternTest.kt
@@ -120,4 +120,18 @@ class TagPatternTest : FunSpec({
             TagPattern.parseProjectPrefixFromBranch(branch, globalPrefix) shouldBe expectedPrefix
         }
     }
+
+    test("branch-to-project matching works for nested project paths") {
+        // given — a nested project like :services:auth-v2 derives to "services-auth-v2"
+        val gradlePath = ":services:auth-v2"
+        val projectPrefix = TagPattern.deriveProjectTagPrefix(gradlePath)
+
+        // when — the release branch uses that derived prefix
+        val branch = "release/$projectPrefix/v1.0.x"
+        val parsedPrefix = TagPattern.parseProjectPrefixFromBranch(branch, "release")
+
+        // then — round-trip: derived prefix matches parsed prefix
+        parsedPrefix shouldBe projectPrefix
+        parsedPrefix shouldBe "services-auth-v2"
+    }
 })


### PR DESCRIPTION
## Summary
- Remove unused `diffBranch()` method from `GitRepository` and its tests (dead code — never called from production code)
- Add integration test for `pushBranchesAtomically` with an empty branch list
- Add unit test for `ChangedProjectsPrinter` with multiple transitive via dependencies
- Add unit test for `TagPattern` branch-to-project round-trip with nested project paths (e.g. `:services:auth-v2`)

## Test plan
- [x] All unit tests pass (`./gradlew unitTest`)
- [x] All integration tests pass (`./gradlew integrationTest`)
- [x] All functional tests pass (`./gradlew functionalTest`)
- [x] No remaining references to removed `diffBranch` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)