### PR TITLE
Fix: bootstrap last-successful-build tag on first run

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -167,6 +167,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
 
                 if (changedProjects.isEmpty()) {
                     project.logger.lifecycle("No projects have changed — nothing to do")
+                    tagUpdater.updateTag(buildExt.lastSuccessfulBuildTag)
                     return@doLast
                 }
 

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
@@ -34,20 +34,36 @@ class BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest : FunSpec({
     // No changed projects
     // ─────────────────────────────────────────────────────────────
 
-    test("succeeds with no branches created and does not update tag when no projects have changed") {
+    test("succeeds with no branches created and updates tag when no projects have changed") {
         // given: tag at HEAD so no changes detected
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
         project.createTag("monorepo/last-successful-build")
         project.pushTag("monorepo/last-successful-build")
-        val tagCommitBefore = project.commitForTag("monorepo/last-successful-build")
+        val headCommit = project.headCommit()
 
         // when
         val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
 
-        // then: tag not moved because there were no changes
+        // then: tag still updated (idempotent) even when no changes detected
         result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "No projects have changed"
         project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
-        project.commitForTag("monorepo/last-successful-build") shouldBe tagCommitBefore
+        project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
+    }
+
+    test("creates tag on first run when no tag exists and no changes since origin/main") {
+        // given: no tag exists, HEAD is at origin/main — simulates first CI run
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        val headCommit = project.headCommit()
+
+        // when
+        val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
+
+        // then: tag bootstrapped so future runs have a baseline
+        result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "No projects have changed"
+        project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
+        project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
     }
 
     // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `buildChangedProjectsAndCreateReleaseBranches` not creating the `monorepo/last-successful-build` tag when no projects have changed
- On a fresh repo where HEAD == `origin/main`, the tag was never bootstrapped, causing every subsequent CI run to fall back to `origin/main`, find no diff, and loop forever
- The "no opted-in projects" path already updated the tag; the "no changes" path was missing it

## Test plan
- [x] Updated existing "no changes" functional test to verify tag is still updated
- [x] Added new test for first-run bootstrap scenario (no tag exists, no changes since `origin/main`)
- [x] All unit, integration, and functional tests pass

Fixes behavior observed in [monorepo-build-release-example run #22813408692](https://github.com/doug-hawley/monorepo-build-release-example/actions/runs/22813408692/job/66174170474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)