### PR TITLE
fix: suppress noisy git rev-parse errors during release branch creation

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
@@ -90,7 +90,7 @@ class GitReleaseExecutor(
     }
 
     fun branchExistsLocally(branch: String): Boolean {
-        val result = executor.execute(rootDir, "rev-parse", "--verify", "refs/heads/$branch")
-        return result.success
+        val result = executor.execute(rootDir, "branch", "--list", branch)
+        return result.success && result.output.isNotEmpty()
     }
 }


### PR DESCRIPTION
## Summary
- Replace `git rev-parse --verify` with `git branch --list` in `GitReleaseExecutor.branchExistsLocally()` to eliminate noisy warnings when checking for non-existent branches during release branch creation
- `git branch --list` always exits 0 regardless of whether the branch exists, so no error output is logged for the expected "branch doesn't exist" case

Closes #109

## Test plan
- [x] All existing tests pass (`./gradlew check` — unit, integration, and functional tests)
- [x] Existing `branchExistsLocally` integration tests cover both true and false cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)