### PR TITLE
perf: speed up functional tests by reducing Gradle TestKit overhead

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,7 @@ val integrationTest by tasks.registering(Test::class) {
     useJUnitPlatform()
     outputs.upToDateWhen { false }
     shouldRunAfter(unitTest)
+    maxParallelForks = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
 }
 
 // Register functional test task
@@ -102,7 +103,7 @@ val functionalTest by tasks.registering(Test::class) {
     useJUnitPlatform()
     outputs.upToDateWhen { false }
     shouldRunAfter(unitTest, integrationTest)
-    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+    maxParallelForks = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
 }
 
 // Make check depend on all test types

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.daemon=false
 kotlin.code.style=official

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
@@ -101,7 +101,7 @@ class TestProjectBuilder(private val projectDir: File) {
                 if (subproject.isBom) {
                     appendLine("    `java-platform`")
                 } else {
-                    appendLine("    kotlin(\"jvm\") version \"2.0.21\"")
+                    appendLine("    java")
                 }
                 appendLine("}")
                 appendLine()
@@ -113,7 +113,7 @@ class TestProjectBuilder(private val projectDir: File) {
                         // First dependency is the platform
                         val platformDep = subproject.dependencies.first()
                         val platformPath = platformDep.replace("/", ":")
-                        appendLine("    api(platform(project(\":$platformPath\")))")
+                        appendLine("    implementation(platform(project(\":$platformPath\")))")
 
                         // Rest are regular dependencies
                         subproject.dependencies.drop(1).forEach { dep ->

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/StandardReleaseTestProject.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/StandardReleaseTestProject.kt
@@ -63,13 +63,18 @@ object StandardReleaseTestProject {
 
         File(appDir, "build.gradle.kts").writeText(
             """
-            plugins {
-                kotlin("jvm") version "2.0.21"
-            }
-
             monorepoProject {
                 release {
                     enabled = true
+                }
+            }
+
+            // Lightweight fake build task: creates the expected artifact so release can proceed
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
                 }
             }
             """.trimIndent()


### PR DESCRIPTION
## Summary
- Replace `kotlin("jvm")` plugin with lightweight `java` plugin in build test fixtures (`TestProjectBuilder`) — change detection doesn't need Kotlin compilation, avoiding heavy classloading/compiler setup per test
- Replace `kotlin("jvm")` with a fake `build` task stub in single-project release fixture (`StandardReleaseTestProject.create()`), matching the pattern already used by `createMultiProject()`
- Remove `org.gradle.daemon=false` from `gradle.properties` to allow Gradle daemon reuse across TestKit runs, amortizing JVM startup cost
- Increase `maxParallelForks` from `availableProcessors / 2` to `availableProcessors` for functional tests, and add `maxParallelForks` to integration tests (both are I/O-bound, not CPU-bound)

Closes #114

## Test plan
- [x] All existing unit, integration, and functional tests pass (`./gradlew check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)