### PR TITLE
feat: fetch refs before baseline resolution

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -206,21 +206,42 @@ class MonorepoBuildReleasePlugin @Inject constructor(
 
     /**
      * Resolves the base ref for change detection.
-     * Returns the last-successful-build tag if it exists, or null when no baseline exists
-     * (which causes all tracked files to be treated as changed).
+     *
+     * Resolution order:
+     * 1. Fetch the last-successful-build tag from origin (best-effort, updates local if remote has moved)
+     * 2. Fetch origin/{primaryBranch} (best-effort, ensures remote-tracking ref is current)
+     * 3. If the tag exists (now guaranteed current) → use it
+     * 4. Else if origin/{primaryBranch} exists → use it as fallback
+     * 5. Else → return null (all projects treated as changed)
+     *
+     * Fetch calls are best-effort: if they fail (no remote configured, network error, etc.),
+     * the method falls through to whatever refs exist locally.
      */
     private fun resolveBaseRef(project: Project, rootExtension: MonorepoExtension): String? {
         val buildExtension = rootExtension.build
         val gitRepository = GitRepository(project.rootDir, project.logger)
         val tag = buildExtension.lastSuccessfulBuildTag
+        val primaryBranch = rootExtension.primaryBranch
+
+        // Best-effort fetch: update the tag and remote-tracking branch from origin
+        gitRepository.fetchRef("origin", tag)
+        gitRepository.fetchRef("origin", primaryBranch)
 
         if (gitRepository.refExists(tag)) {
             project.logger.info("Using last-successful-build tag '$tag' as base ref")
             return tag
         }
 
+        val remoteBranch = "origin/$primaryBranch"
+        if (gitRepository.refExists(remoteBranch)) {
+            project.logger.lifecycle(
+                "Tag '$tag' not found — falling back to '$remoteBranch' as base ref."
+            )
+            return remoteBranch
+        }
+
         project.logger.lifecycle(
-            "Tag '$tag' not found — no baseline exists. " +
+            "Tag '$tag' not found and '$remoteBranch' is not available — no baseline exists. " +
             "All projects will be treated as changed."
         )
         return null

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
@@ -10,7 +10,12 @@ open class MonorepoBuildExtension {
     /**
      * The tag name that the plugin reads from and writes to for tracking the
      * last successful build. Change detection compares HEAD against this tag.
-     * When the tag doesn't exist, all projects are treated as changed.
+     *
+     * During baseline resolution the plugin fetches this tag from origin
+     * (best-effort) to ensure the local copy is current, then checks whether
+     * it exists. If it does not, the plugin falls back to
+     * `origin/{primaryBranch}`. When neither ref is available, all projects
+     * are treated as changed.
      */
     var lastSuccessfulBuildTag: String = "monorepo/last-successful-build"
 
@@ -27,6 +32,9 @@ open class MonorepoBuildExtension {
     /**
      * The ref that was actually used for change detection, or null when no baseline exists
      * (all projects treated as changed). Set internally after ref resolution.
+     *
+     * This may be the [lastSuccessfulBuildTag], `origin/{primaryBranch}` (fallback),
+     * or null when neither ref is available.
      */
     var resolvedBaseRef: String? = null
         internal set

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
@@ -89,6 +89,16 @@ open class GitRepository(
         return gitExecutor.execute(dir, "rev-parse", "--verify", ref).success
     }
 
+    /**
+     * Fetches a single ref from a remote.
+     * Returns true if the fetch succeeded, false otherwise (e.g. no remote configured,
+     * network error, ref not found on remote).
+     */
+    open fun fetchRef(remote: String, refspec: String): Boolean {
+        val dir = gitDir ?: return false
+        return gitExecutor.execute(dir, "fetch", remote, refspec, "--quiet").success
+    }
+
     private fun findGitRoot(startDir: File): File? {
         var current: File? = startDir
         while (current != null) {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFunctionalTest.kt
@@ -250,7 +250,7 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         result.output shouldContain "No projects have changed - nothing to build"
     }
 
-    test("buildChangedProjects treats all projects as changed when tag does not exist") {
+    test("buildChangedProjects falls back to origin/main when tag does not exist") {
         // given: project with remote but no last-successful-build tag
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -258,10 +258,32 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
         project.executeGitCommand("tag", "-d", "monorepo/last-successful-build")
 
+        // Make a change after deleting the tag so there is something to detect
+        project.appendToFile(Files.APP2_SOURCE, "\n// Modified after tag removal")
+        project.commitAll("Change app2 after tag removal")
+
         // when
         val result = project.runTask("buildChangedProjects")
 
-        // then: no baseline exists, so all projects are treated as changed
+        // then: falls back to origin/main as baseline and detects the change
+        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "falling back to 'origin/main'"
+        val built = result.extractBuiltProjects()
+        built shouldContain Projects.APP2
+    }
+
+    test("buildChangedProjects treats all projects as changed when no baseline is available") {
+        // given: project without remote and no tag
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = false
+        )
+        project.executeGitCommand("tag", "-d", "monorepo/last-successful-build")
+
+        // when
+        val result = project.runTask("buildChangedProjects")
+
+        // then: no tag and no origin/main — no baseline exists
         result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no baseline"
         val built = result.extractBuiltProjects()

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest.kt
@@ -213,19 +213,22 @@ class BuildChangedProjectsAndCreateReleaseBranchesFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
-    // No baseline (tag does not exist)
+    // No tag — falls back to origin/main
     // ─────────────────────────────────────────────────────────────
 
     test("creates release branches for all opted-in projects when tag does not exist") {
-        // given: no tag — all projects treated as changed
+        // given: no tag — falls back to origin/main; make changes so projects are detected
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.modifyFile("app/app.txt", "changed app")
+        project.modifyFile("lib/lib.txt", "changed lib")
+        project.commitAll("Change all projects")
 
         // when
         val result = project.runTask("buildChangedProjectsAndCreateReleaseBranches")
 
-        // then: both opted-in projects get release branches
+        // then: falls back to origin/main, detects changes, creates release branches
         result.task(":buildChangedProjectsAndCreateReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.output shouldContain "no baseline"
+        result.output shouldContain "falling back to 'origin/main'"
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldContain "release/lib/v0.1.x"
     }

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
@@ -181,6 +181,70 @@ class GitRepositoryTest : FunSpec({
     test("refExists returns false for a ref that does not exist") {
         GitRepository(repoDir, logger).refExists("nonexistent-branch") shouldBe false
     }
+
+    // --- fetchRef ---
+
+    test("fetchRef returns true when fetching an existing ref from a remote") {
+        // given: ensure branch is named main, set up a bare remote and push
+        git(repoDir, "checkout", "-B", "main")
+        val remoteDir = Files.createTempDirectory("test-git-remote").toFile()
+        try {
+            git(remoteDir, "init", "--bare")
+            git(repoDir, "remote", "add", "origin", remoteDir.absolutePath)
+            git(repoDir, "push", "-u", "origin", "main")
+
+            // when
+            val result = GitRepository(repoDir, logger).fetchRef("origin", "main")
+
+            // then
+            result shouldBe true
+        } finally {
+            remoteDir.deleteRecursively()
+        }
+    }
+
+    test("fetchRef returns false when remote does not exist") {
+        // given: no remote configured
+
+        // when
+        val result = GitRepository(repoDir, logger).fetchRef("origin", "main")
+
+        // then
+        result shouldBe false
+    }
+
+    test("fetchRef returns false when ref does not exist on remote") {
+        // given: ensure branch is named main, set up a bare remote
+        git(repoDir, "checkout", "-B", "main")
+        val remoteDir = Files.createTempDirectory("test-git-remote").toFile()
+        try {
+            git(remoteDir, "init", "--bare")
+            git(repoDir, "remote", "add", "origin", remoteDir.absolutePath)
+            git(repoDir, "push", "-u", "origin", "main")
+
+            // when: fetch a nonexistent ref
+            val result = GitRepository(repoDir, logger).fetchRef("origin", "nonexistent-ref")
+
+            // then
+            result shouldBe false
+        } finally {
+            remoteDir.deleteRecursively()
+        }
+    }
+
+    test("fetchRef returns false when not inside a git repository") {
+        // given
+        val nonGitDir = Files.createTempDirectory("test-no-git").toFile()
+        try {
+            // when
+            val result = GitRepository(nonGitDir, logger).fetchRef("origin", "main")
+
+            // then
+            result shouldBe false
+        } finally {
+            nonGitDir.deleteRecursively()
+        }
+    }
 })
 
 private fun git(directory: File, vararg command: String) {


### PR DESCRIPTION
## Summary

- Add `fetchRef(remote, refspec)` method to `GitRepository` that runs `git fetch <remote> <refspec> --quiet`
- Rewrite `resolveBaseRef` to fetch the tag and `origin/{primaryBranch}` before resolution, then fall back to `origin/{primaryBranch}` when the tag doesn't exist
- Update KDoc on `MonorepoBuildExtension` to document the new fallback chain
- Add unit tests for `fetchRef` (success, no remote, nonexistent ref, non-git dir)
- Update functional tests that relied on "no tag = no baseline" behavior to account for the `origin/main` fallback

Closes #121

## Test plan

- [x] All 84 unit, integration, and functional tests pass (`./gradlew check`)
- [ ] Verify `printChangedProjects` uses stale tag correctly after fetch updates it
- [ ] Verify `origin/main` fallback works when tag doesn't exist but remote does
- [ ] Verify "no baseline" behavior still works when neither tag nor remote exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)