### PR TITLE
fix: address code audit findings from #132

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadata.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadata.kt
@@ -10,13 +10,21 @@ data class ProjectMetadata(
      * Returns true if this project has changed files OR any of its dependencies have changes (recursively).
      */
     fun hasChanges(): Boolean {
+        return hasChanges(mutableSetOf())
+    }
+
+    private fun hasChanges(visited: MutableSet<String>): Boolean {
+        if (!visited.add(fullyQualifiedName)) {
+            return false
+        }
+
         // Check if this project has direct changes
         if (changedFiles.isNotEmpty()) {
             return true
         }
 
         // Check if any dependency has changes (recursively)
-        return dependencies.any { it.hasChanges() }
+        return dependencies.any { it.hasChanges(visited) }
     }
 
     /**

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
@@ -104,7 +104,11 @@ open class GitRepository(
         if (result.success) {
             return true
         }
-        if (result.errorOutput.contains("couldn't find remote ref")) {
+        // Exit code 128 is used for both "missing ref" and "unreachable remote".
+        // When the ref is missing, git includes the tag name in the error
+        // (e.g., "couldn't find remote ref refs/tags/<tagName>") regardless
+        // of locale. Transport/auth errors do not mention the tag name.
+        if (result.exitCode == 128 && result.errorOutput.contains(tagName)) {
             return false
         }
         throw RuntimeException(

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/LastSuccessfulBuildTagUpdater.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/LastSuccessfulBuildTagUpdater.kt
@@ -18,9 +18,10 @@ class LastSuccessfulBuildTagUpdater(
      * Updates the tag to point at HEAD and pushes it to the remote.
      *
      * @param tagName the tag to update (e.g., "monorepo/last-successful-build")
+     * @return true if the tag was pushed to the remote, false if the push failed
      * @throws RuntimeException if the local tag creation fails
      */
-    fun updateTag(tagName: String) {
+    fun updateTag(tagName: String): Boolean {
         // Force-create tag locally at HEAD
         val tagResult = executor.execute(rootDir, "tag", "-f", tagName, "HEAD")
         if (!tagResult.success) {
@@ -38,8 +39,9 @@ class LastSuccessfulBuildTagUpdater(
                 "The build succeeded but the tag was not pushed. " +
                 "The next build may re-process already-built changes."
             )
-            return
+            return false
         }
         logger.lifecycle("Pushed tag '$tagName' to remote")
+        return true
     }
 }

--- a/src/main/kotlin/io/github/doughawley/monorepo/git/GitCommandExecutor.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/git/GitCommandExecutor.kt
@@ -32,67 +32,7 @@ class GitCommandExecutor(private val logger: Logger) {
      * @return CommandResult containing success status, output, and error information
      */
     fun execute(directory: File, vararg command: String): CommandResult {
-        val fullCommand = arrayOf("git") + command
-
-        val process = try {
-            ProcessBuilder(*fullCommand)
-                .directory(directory)
-                .redirectErrorStream(true)
-                .start()
-        } catch (e: Exception) {
-            logger.error("Exception starting git command: ${fullCommand.joinToString(" ")}", e)
-            return CommandResult(
-                success = false,
-                output = emptyList(),
-                exitCode = -1,
-                errorOutput = e.message ?: "Unknown error"
-            )
-        }
-
-        return try {
-            val exitCode = process.waitFor()
-            val output = process.inputStream.bufferedReader().use { reader ->
-                reader.readLines().filter { it.isNotBlank() }
-            }
-
-            if (exitCode == 0) {
-                CommandResult(
-                    success = true,
-                    output = output,
-                    exitCode = exitCode
-                )
-            } else {
-                val errorOutput = output.joinToString("\n")
-                logger.warn("Git command failed with exit code $exitCode: ${fullCommand.joinToString(" ")}")
-                logger.warn("Error output: $errorOutput")
-
-                CommandResult(
-                    success = false,
-                    output = emptyList(),
-                    exitCode = exitCode,
-                    errorOutput = errorOutput
-                )
-            }
-        } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
-            logger.error("Interrupted waiting for git command: ${fullCommand.joinToString(" ")}", e)
-            CommandResult(
-                success = false,
-                output = emptyList(),
-                exitCode = -1,
-                errorOutput = e.message ?: "Interrupted"
-            )
-        } catch (e: Exception) {
-            logger.error("Exception executing git command: ${fullCommand.joinToString(" ")}", e)
-            CommandResult(
-                success = false,
-                output = emptyList(),
-                exitCode = -1,
-                errorOutput = e.message ?: "Unknown error"
-            )
-        } finally {
-            process.destroy()
-        }
+        return runCommand(directory, silent = false, command = command)
     }
 
     /**
@@ -106,67 +46,7 @@ class GitCommandExecutor(private val logger: Logger) {
      * @return CommandResult containing success status, output, and error information
      */
     fun executeSilently(directory: File, vararg command: String): CommandResult {
-        val fullCommand = arrayOf("git") + command
-
-        val process = try {
-            ProcessBuilder(*fullCommand)
-                .directory(directory)
-                .redirectErrorStream(true)
-                .start()
-        } catch (e: Exception) {
-            logger.debug("Exception starting git command: ${fullCommand.joinToString(" ")}", e)
-            return CommandResult(
-                success = false,
-                output = emptyList(),
-                exitCode = -1,
-                errorOutput = e.message ?: "Unknown error"
-            )
-        }
-
-        return try {
-            val exitCode = process.waitFor()
-            val output = process.inputStream.bufferedReader().use { reader ->
-                reader.readLines().filter { it.isNotBlank() }
-            }
-
-            if (exitCode == 0) {
-                CommandResult(
-                    success = true,
-                    output = output,
-                    exitCode = exitCode
-                )
-            } else {
-                val errorOutput = output.joinToString("\n")
-                logger.debug("Git command exited with code $exitCode: ${fullCommand.joinToString(" ")}")
-                logger.debug("Output: $errorOutput")
-
-                CommandResult(
-                    success = false,
-                    output = emptyList(),
-                    exitCode = exitCode,
-                    errorOutput = errorOutput
-                )
-            }
-        } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
-            logger.debug("Interrupted waiting for git command: ${fullCommand.joinToString(" ")}", e)
-            CommandResult(
-                success = false,
-                output = emptyList(),
-                exitCode = -1,
-                errorOutput = e.message ?: "Interrupted"
-            )
-        } catch (e: Exception) {
-            logger.debug("Exception executing git command: ${fullCommand.joinToString(" ")}", e)
-            CommandResult(
-                success = false,
-                output = emptyList(),
-                exitCode = -1,
-                errorOutput = e.message ?: "Unknown error"
-            )
-        } finally {
-            process.destroy()
-        }
+        return runCommand(directory, silent = true, command = command)
     }
 
     /**
@@ -180,5 +60,88 @@ class GitCommandExecutor(private val logger: Logger) {
     fun executeForOutput(directory: File, vararg command: String): List<String> {
         val result = execute(directory, *command)
         return if (result.success) result.output else emptyList()
+    }
+
+    private fun runCommand(directory: File, silent: Boolean, vararg command: String): CommandResult {
+        val fullCommand = arrayOf("git") + command
+
+        val process = try {
+            ProcessBuilder(*fullCommand)
+                .directory(directory)
+                .redirectErrorStream(true)
+                .start()
+        } catch (e: Exception) {
+            if (silent) {
+                logger.debug("Exception starting git command: ${fullCommand.joinToString(" ")}", e)
+            } else {
+                logger.error("Exception starting git command: ${fullCommand.joinToString(" ")}", e)
+            }
+            return CommandResult(
+                success = false,
+                output = emptyList(),
+                exitCode = -1,
+                errorOutput = e.message ?: "Unknown error"
+            )
+        }
+
+        return try {
+            // Read the output stream before waitFor() to avoid deadlock when
+            // the process produces more output than the OS pipe buffer (~64KB).
+            val output = process.inputStream.bufferedReader().use { reader ->
+                reader.readLines().filter { it.isNotBlank() }
+            }
+            val exitCode = process.waitFor()
+
+            if (exitCode == 0) {
+                CommandResult(
+                    success = true,
+                    output = output,
+                    exitCode = exitCode
+                )
+            } else {
+                val errorOutput = output.joinToString("\n")
+                if (silent) {
+                    logger.debug("Git command exited with code $exitCode: ${fullCommand.joinToString(" ")}")
+                    logger.debug("Output: $errorOutput")
+                } else {
+                    logger.warn("Git command failed with exit code $exitCode: ${fullCommand.joinToString(" ")}")
+                    logger.warn("Error output: $errorOutput")
+                }
+
+                CommandResult(
+                    success = false,
+                    output = emptyList(),
+                    exitCode = exitCode,
+                    errorOutput = errorOutput
+                )
+            }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            if (silent) {
+                logger.debug("Interrupted waiting for git command: ${fullCommand.joinToString(" ")}", e)
+            } else {
+                logger.error("Interrupted waiting for git command: ${fullCommand.joinToString(" ")}", e)
+            }
+            CommandResult(
+                success = false,
+                output = emptyList(),
+                exitCode = -1,
+                errorOutput = e.message ?: "Interrupted"
+            )
+        } catch (e: Exception) {
+            if (silent) {
+                logger.debug("Exception executing git command: ${fullCommand.joinToString(" ")}", e)
+            } else {
+                logger.error("Exception executing git command: ${fullCommand.joinToString(" ")}", e)
+            }
+            CommandResult(
+                success = false,
+                output = emptyList(),
+                exitCode = -1,
+                errorOutput = e.message ?: "Unknown error"
+            )
+        } finally {
+            process.destroy()
+        }
     }
 }

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/build/git/LastSuccessfulBuildTagUpdaterIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/build/git/LastSuccessfulBuildTagUpdaterIntegrationTest.kt
@@ -27,9 +27,10 @@ class LastSuccessfulBuildTagUpdaterIntegrationTest : FunSpec({
         val updater = createUpdater()
 
         // when
-        updater.updateTag("monorepo/last-successful-build")
+        val result = updater.updateTag("monorepo/last-successful-build")
 
         // then
+        result shouldBe true
         repoListener.repo.localTagExists("monorepo/last-successful-build") shouldBe true
         repoListener.repo.remoteTagExists("monorepo/last-successful-build") shouldBe true
     }
@@ -59,5 +60,27 @@ class LastSuccessfulBuildTagUpdaterIntegrationTest : FunSpec({
         // then
         repoListener.repo.localTagExists("custom/prefix/last-build") shouldBe true
         repoListener.repo.remoteTagExists("custom/prefix/last-build") shouldBe true
+    }
+
+    test("returns false when push to remote fails") {
+        // given: point origin at a non-existent path so the push will fail
+        val executor = GitCommandExecutor(logger)
+        val localDir = repoListener.repo.localDir
+        val brokenRemoteExecutor = GitCommandExecutor(logger)
+
+        // Remove the working remote and add a broken one
+        val removeResult = executor.execute(localDir, "remote", "remove", "origin")
+        removeResult.success shouldBe true
+        val addResult = executor.execute(localDir, "remote", "add", "origin", "/nonexistent/broken/remote")
+        addResult.success shouldBe true
+
+        val updater = LastSuccessfulBuildTagUpdater(localDir, brokenRemoteExecutor, logger)
+
+        // when
+        val result = updater.updateTag("monorepo/last-successful-build")
+
+        // then: tag created locally, but push failed
+        result shouldBe false
+        repoListener.repo.localTagExists("monorepo/last-successful-build") shouldBe true
     }
 })

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataTest.kt
@@ -120,6 +120,72 @@ class ProjectMetadataTest : FunSpec({
         buildChain(20, hasChange = false).hasChanges() shouldBe false
     }
 
+    test("hasChanges handles diamond dependency graphs without double-counting") {
+        // given: A → B, A → C, B → D, C → D  (diamond shape, D has changes)
+        val sharedDep = ProjectMetadata(
+            name = "shared",
+            fullyQualifiedName = ":shared",
+            changedFiles = listOf("shared/File.kt")
+        )
+
+        val depB = ProjectMetadata(
+            name = "dep-b",
+            fullyQualifiedName = ":dep-b",
+            dependencies = listOf(sharedDep),
+            changedFiles = emptyList()
+        )
+
+        val depC = ProjectMetadata(
+            name = "dep-c",
+            fullyQualifiedName = ":dep-c",
+            dependencies = listOf(sharedDep),
+            changedFiles = emptyList()
+        )
+
+        val root = ProjectMetadata(
+            name = "root",
+            fullyQualifiedName = ":root",
+            dependencies = listOf(depB, depC),
+            changedFiles = emptyList()
+        )
+
+        // then — visited tracking avoids re-traversing :shared via depC
+        root.hasChanges() shouldBe true
+    }
+
+    test("hasChanges returns false for diamond dependency graph with no changes") {
+        // given: same diamond shape but no changes anywhere
+        val sharedDep = ProjectMetadata(
+            name = "shared",
+            fullyQualifiedName = ":shared",
+            changedFiles = emptyList()
+        )
+
+        val depB = ProjectMetadata(
+            name = "dep-b",
+            fullyQualifiedName = ":dep-b",
+            dependencies = listOf(sharedDep),
+            changedFiles = emptyList()
+        )
+
+        val depC = ProjectMetadata(
+            name = "dep-c",
+            fullyQualifiedName = ":dep-c",
+            dependencies = listOf(sharedDep),
+            changedFiles = emptyList()
+        )
+
+        val root = ProjectMetadata(
+            name = "root",
+            fullyQualifiedName = ":root",
+            dependencies = listOf(depB, depC),
+            changedFiles = emptyList()
+        )
+
+        // then
+        root.hasChanges() shouldBe false
+    }
+
     test("toString includes dependency count and file count") {
         // given
         val dep1 = ProjectMetadata("dep1", ":dep1")

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
@@ -249,6 +249,23 @@ class GitRepositoryTest : FunSpec({
         }
     }
 
+    test("fetchTag returns false for missing tag with slash-delimited name") {
+        // given: validates exit-code-based detection works for namespaced tags
+        val remoteDir = Files.createTempDirectory("test-git-remote").toFile()
+        git(remoteDir, "init", "--bare")
+        git(repoDir, "remote", "add", "origin", remoteDir.absolutePath)
+        git(repoDir, "push", "-u", "origin", "main")
+
+        val repo = GitRepository(repoDir, logger)
+
+        // when
+        val result = repo.fetchTag("origin", "monorepo/last-successful-build")
+
+        // then
+        result shouldBe false
+        remoteDir.deleteRecursively()
+    }
+
     test("fetchTag updates local tag when remote tag has moved") {
         // given: set up remote, create tag, push it
         val remoteDir = Files.createTempDirectory("test-git-remote").toFile()


### PR DESCRIPTION
## Summary
- **[High] Fix deadlock in `GitCommandExecutor`**: Read process output stream before `waitFor()` to prevent blocking when git output exceeds the OS pipe buffer (~64KB). Consolidated `execute()` and `executeSilently()` into a shared `runCommand()` to eliminate duplication.
- **[Medium] Locale-resilient `fetchTag()`**: Replaced fragile English error string matching (`"couldn't find remote ref"`) with exit code 128 + tag name presence check, which works across git locales.
- **[Low] Cycle protection in `ProjectMetadata.hasChanges()`**: Added visited-set tracking consistent with `MonorepoProjects.hasDependencyOn()`.
- **[Low] `LastSuccessfulBuildTagUpdater.updateTag()` return value**: Changed from `Unit` to `Boolean` so callers can detect push failures.

## Test plan
- [x] Added diamond dependency graph tests for `ProjectMetadata.hasChanges()` visited-set behavior
- [x] Added `fetchTag` test for slash-delimited tag names with exit-code-based detection
- [x] Updated `LastSuccessfulBuildTagUpdater` tests to assert `Boolean` return value
- [x] Added test for `updateTag` returning `false` when push fails
- [x] All existing unit, integration, and functional tests pass (`./gradlew check`)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)