### PR TITLE
feat: log change detection baseline at lifecycle level

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -79,6 +79,16 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                 try {
                     val resolvedRef = resolveBaseRef(project.rootProject, rootExtension)
                     rootBuildExtension.resolvedBaseRef = resolvedRef
+
+                    val gitRepository = GitRepository(project.rootProject.rootDir, project.logger)
+                    if (resolvedRef != null) {
+                        val resolvedCommit = gitRepository.resolveCommit(resolvedRef)
+                        rootBuildExtension.resolvedBaseCommit = resolvedCommit
+                        project.logger.lifecycle("Change detection baseline: $resolvedRef ($resolvedCommit)")
+                    } else {
+                        project.logger.lifecycle("Change detection baseline: none (all projects treated as changed)")
+                    }
+
                     computeMetadata(project.rootProject, rootBuildExtension, resolvedRef)
                     wireDependsOn(project, "buildChangedProjects", rootBuildExtension.allAffectedProjects)
                     rootBuildExtension.metadataComputed = true
@@ -236,7 +246,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
             gitRepository.fetchTag("origin", tag)
 
             if (gitRepository.refExists(tag)) {
-                project.logger.info("Using last-successful-build tag '$tag' as base ref")
+                project.logger.debug("Using last-successful-build tag '$tag' as base ref")
                 return tag
             }
             if (gitRepository.refExists(remoteBranch)) {
@@ -253,7 +263,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
         }
 
         if (gitRepository.refExists(remoteBranch)) {
-            project.logger.info("Using '$remoteBranch' as base ref")
+            project.logger.debug("Using '$remoteBranch' as base ref")
             return remoteBranch
         }
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
@@ -44,6 +44,13 @@ open class MonorepoBuildExtension {
         internal set
 
     /**
+     * The abbreviated commit SHA that [resolvedBaseRef] points to, or null when no baseline exists.
+     * Set alongside [resolvedBaseRef] after ref resolution.
+     */
+    var resolvedBaseCommit: String? = null
+        internal set
+
+    /**
      * All monorepo projects with their metadata and change information.
      * Available after configuration phase completes.
      */

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
@@ -89,6 +89,13 @@ open class GitRepository(
         return gitExecutor.executeSilently(dir, "rev-parse", "--verify", ref).success
     }
 
+    /** Returns the abbreviated commit SHA for [ref], or null if the ref does not exist. */
+    open fun resolveCommit(ref: String): String? {
+        val dir = gitDir ?: return null
+        val result = gitExecutor.executeSilently(dir, "rev-parse", "--short", ref)
+        return if (result.success) result.output.firstOrNull()?.trim() else null
+    }
+
     /**
      * Fetches a tag from a remote, updating the local tag to match.
      * Uses `git fetch <remote> tag <tagName> --force --quiet` so the local

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/task/PrintChangedProjectsTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/task/PrintChangedProjectsTask.kt
@@ -34,8 +34,10 @@ abstract class PrintChangedProjectsTask : DefaultTask() {
         }
 
         val resolvedRef = buildExtension.resolvedBaseRef
+        val resolvedCommit = buildExtension.resolvedBaseCommit
         val header = if (resolvedRef != null) {
-            "Changed projects (since $resolvedRef):"
+            val commitSuffix = if (resolvedCommit != null) " @ $resolvedCommit" else ""
+            "Changed projects (since $resolvedRef$commitSuffix):"
         } else {
             "Changed projects (no baseline — all projects):"
         }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedProjectsFunctionalTest.kt
@@ -187,6 +187,24 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
     }
 
+    test("buildChangedProjects logs the change detection baseline") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        project.appendToFile(Files.APP2_SOURCE, "\n// Modified")
+        project.commitAll("Modify app2")
+
+        // when
+        val result = project.runTask("buildChangedProjects")
+
+        // then
+        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "Change detection baseline: origin/main ("
+    }
+
     // --- origin/main baseline scenarios ---
 
     test("buildChangedProjects uses origin/main as baseline and detects direct change") {
@@ -290,6 +308,7 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         // then: no origin/main — no baseline exists
         result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no baseline"
+        result.output shouldContain "Change detection baseline: none"
         val built = result.extractBuiltProjects()
         built shouldContain Projects.APP1
         built shouldContain Projects.APP2

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/PrintChangedProjectsFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/PrintChangedProjectsFunctionalTest.kt
@@ -305,6 +305,7 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
 
         // then
         result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.output shouldContain "Changed projects (since origin/main):"
+        result.output shouldContain "Change detection baseline: origin/main ("
+        result.output shouldContain "Changed projects (since origin/main @"
     }
 })

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesFunctionalTest.kt
@@ -149,6 +149,7 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
 
         // then: proves the tag is used — app has a release branch
         result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "Change detection baseline: monorepo/last-successful-build ("
         project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
 
@@ -342,6 +343,7 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         // then: falls back to origin/main, detects changes, creates release branches
         result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "falling back to 'origin/main'"
+        result.output shouldContain "Change detection baseline: origin/main ("
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldContain "release/lib/v0.1.x"
     }

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.mockk
 import java.io.File
 import java.nio.file.Files
@@ -180,6 +181,41 @@ class GitRepositoryTest : FunSpec({
 
     test("refExists returns false for a ref that does not exist") {
         GitRepository(repoDir, logger).refExists("nonexistent-branch") shouldBe false
+    }
+
+    // --- resolveCommit ---
+
+    test("resolveCommit returns short hash for an existing ref") {
+        // given — HEAD exists after initial commit
+
+        // when
+        val result = GitRepository(repoDir, logger).resolveCommit("HEAD")
+
+        // then
+        result shouldNotBe null
+        result!!.length shouldBe 7
+    }
+
+    test("resolveCommit returns null for a non-existent ref") {
+        // when
+        val result = GitRepository(repoDir, logger).resolveCommit("nonexistent-ref-xyz")
+
+        // then
+        result shouldBe null
+    }
+
+    test("resolveCommit returns null when not in a git repository") {
+        // given
+        val nonGitDir = Files.createTempDirectory("test-no-git").toFile()
+        try {
+            // when
+            val result = GitRepository(nonGitDir, logger).resolveCommit("HEAD")
+
+            // then
+            result shouldBe null
+        } finally {
+            nonGitDir.deleteRecursively()
+        }
     }
 
     // --- fetchTag ---


### PR DESCRIPTION
## Summary
- Add lifecycle-level log line showing which git ref and commit SHA the plugin chose as the change detection baseline (e.g., `Change detection baseline: origin/main (abc1234)`)
- Include the commit SHA in the `printChangedProjects` report header (e.g., `Changed projects (since origin/main @ abc1234):`)
- Add `resolveCommit()` method to `GitRepository` and `resolvedBaseCommit` property to `MonorepoBuildExtension`
- Demote success-path ref resolution messages from `info` to `debug` since the new lifecycle message covers user-facing output

## Test plan
- [x] Unit tests for `resolveCommit()` (existing ref, non-existent ref, non-git dir)
- [x] Functional test assertions for baseline logging across `printChangedProjects`, `buildChangedProjects`, and `createReleaseBranches`
- [x] `./gradlew check` passes (all unit, integration, and functional tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)