### PR TITLE
fix: treat all projects as changed when last-successful-build tag is missing

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -220,8 +220,9 @@ class MonorepoBuildReleasePlugin @Inject constructor(
      * The baseline depends on which task the user requested:
      * - If `createReleaseBranches` is requested (CI release build) →
      *   fetch the last-successful-build tag from origin (many CI environments
-     *   do not fetch tags by default), then use it; fall back to
-     *   `origin/{primaryBranch}` if the tag does not exist
+     *   do not fetch tags by default), then use it; if the tag does not exist,
+     *   return null so all projects are treated as changed (the first build on
+     *   main has no prior successful build to compare against)
      * - Otherwise (local dev / PR build) → use `origin/{primaryBranch}` directly
      *
      * If the chosen ref does not exist, returns null (all projects treated as changed).
@@ -249,14 +250,8 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                 project.logger.debug("Using last-successful-build tag '$tag' as base ref")
                 return tag
             }
-            if (gitRepository.refExists(remoteBranch)) {
-                project.logger.lifecycle(
-                    "Tag '$tag' not found — falling back to '$remoteBranch' as base ref."
-                )
-                return remoteBranch
-            }
             project.logger.lifecycle(
-                "Tag '$tag' not found and '$remoteBranch' is not available — no baseline exists. " +
+                "Tag '$tag' not found — no baseline exists. " +
                 "All projects will be treated as changed."
             )
             return null

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesFunctionalTest.kt
@@ -327,23 +327,20 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
-    // No tag — falls back to origin/main
+    // No tag — all projects treated as changed
     // ─────────────────────────────────────────────────────────────
 
     test("creates release branches for all opted-in projects when tag does not exist") {
-        // given: no tag — falls back to origin/main; make changes so projects are detected
+        // given: no tag — all projects treated as changed (no baseline)
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
-        project.modifyFile("app/app.txt", "changed app")
-        project.modifyFile("lib/lib.txt", "changed lib")
-        project.commitAll("Change all projects")
 
         // when
         val result = project.runTask("createReleaseBranches")
 
-        // then: falls back to origin/main, detects changes, creates release branches
+        // then: no baseline, all projects treated as changed, release branches created
         result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.output shouldContain "falling back to 'origin/main'"
-        result.output shouldContain "Change detection baseline: origin/main ("
+        result.output shouldContain "no baseline exists"
+        result.output shouldContain "Change detection baseline: none (all projects treated as changed)"
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldContain "release/lib/v0.1.x"
     }


### PR DESCRIPTION
## Summary

Fixes #136.

- When `createReleaseBranches` ran on main without the `monorepo/last-successful-build` tag, the plugin fell back to `origin/main` as baseline. After a PR merge, `origin/main` == HEAD, producing an empty diff and detecting no changed projects.
- Removed the `origin/main` fallback for release runs so that a missing tag correctly results in no baseline, treating all projects as changed.

## Test plan

- [x] Updated functional test "creates release branches for all opted-in projects when tag does not exist" to verify new behavior (no baseline, all projects changed)
- [x] Full `./gradlew check` passes (unit, integration, functional tests + plugin validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)