### PR TITLE
fix: only print change detection baseline for change-detection tasks

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -84,9 +84,14 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                     if (resolvedRef != null) {
                         val resolvedCommit = gitRepository.resolveCommit(resolvedRef)
                         rootBuildExtension.resolvedBaseCommit = resolvedCommit
-                        project.logger.lifecycle("Change detection baseline: $resolvedRef ($resolvedCommit)")
-                    } else {
-                        project.logger.lifecycle("Change detection baseline: none (all projects treated as changed)")
+                    }
+
+                    if (isChangeDetectionRun(project)) {
+                        if (resolvedRef != null) {
+                            project.logger.lifecycle("Change detection baseline: $resolvedRef (${rootBuildExtension.resolvedBaseCommit})")
+                        } else {
+                            project.logger.lifecycle("Change detection baseline: none (all projects treated as changed)")
+                        }
                     }
 
                     computeMetadata(project.rootProject, rootBuildExtension, resolvedRef)
@@ -267,6 +272,19 @@ class MonorepoBuildReleasePlugin @Inject constructor(
             "All projects will be treated as changed."
         )
         return null
+    }
+
+    /**
+     * Returns true if the requested tasks include a change-detection task
+     * whose output benefits from a visible baseline log message.
+     */
+    private fun isChangeDetectionRun(project: Project): Boolean {
+        val changeDetectionTasks = setOf(
+            "printChangedProjects", ":printChangedProjects",
+            "buildChangedProjects", ":buildChangedProjects",
+            "createReleaseBranches", ":createReleaseBranches"
+        )
+        return project.gradle.startParameter.taskNames.any { it in changeDetectionTasks }
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #139.

- The "Change detection baseline: ..." message was printed at lifecycle level for every task, including per-subproject `release` tasks where it is irrelevant and confusing.
- Added `isChangeDetectionRun()` helper that checks the requested tasks against the set of change-detection tasks (`printChangedProjects`, `buildChangedProjects`, `createReleaseBranches`).
- The baseline message is now only printed at lifecycle level when one of those tasks is requested.

## Test plan

- [x] Full `./gradlew check` passes (unit, integration, functional tests + plugin validation)
- [ ] Manually verify that running `:app:release` no longer prints the baseline message

🤖 Generated with [Claude Code](https://claude.com/claude-code)