### PR TITLE
fix: log affected projects during configuration phase (#145)

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -95,6 +95,16 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                     }
 
                     computeMetadata(project.rootProject, rootBuildExtension, resolvedRef)
+
+                    if (isChangeDetectionRun(project)) {
+                        val affectedProjects = rootBuildExtension.allAffectedProjects
+                        if (affectedProjects.isEmpty()) {
+                            project.logger.lifecycle("No projects have changed - nothing to build")
+                        } else {
+                            project.logger.lifecycle("Affected projects: ${affectedProjects.joinToString(", ")}")
+                        }
+                    }
+
                     wireDependsOn(project, "buildChangedProjects", rootBuildExtension.allAffectedProjects)
                     rootBuildExtension.metadataComputed = true
                     project.logger.debug("Changed project metadata computed successfully in configuration phase")
@@ -129,12 +139,6 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                         "or an error occurred during project evaluation. " +
                         "Re-run with --info or --debug for more details."
                     )
-                }
-                val changedProjects = ext.allAffectedProjects
-                if (changedProjects.isEmpty()) {
-                    logger.lifecycle("No projects have changed - nothing to build")
-                } else {
-                    logger.lifecycle("Building changed projects: ${changedProjects.joinToString(", ")}")
                 }
             }
         }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
@@ -323,7 +323,7 @@ fun BuildResult.extractDirectlyChangedProjects(): Set<String> {
 }
 
 fun BuildResult.extractBuiltProjects(): Set<String> {
-    val regex = """Building changed projects: (.*)""".toRegex()
+    val regex = """Affected projects: (.*)""".toRegex()
     val match = regex.find(output)
     val projectsString = match?.groupValues?.get(1)?.trim() ?: ""
 


### PR DESCRIPTION
## Summary
- Moves "affected projects" logging from the `buildChangedProjects` `doLast` block to the configuration phase, right after metadata is computed — so users see which projects are affected **before** builds run, not after.
- Simplifies the `buildChangedProjects` `doLast` block to only retain the metadata-computed safety guard.
- Updates the `extractBuiltProjects()` test helper regex to match the new `"Affected projects: ..."` format.

Closes #145

## Test plan
- [x] `./gradlew check` passes (unit, integration, and functional tests)
- [ ] Verify `buildChangedProjects` output shows "Affected projects: ..." line before build task execution in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)