### PR TITLE
Rename createReleaseBranches to createReleaseBranchesForChangedProjects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ The functional tests use a standard 5-module dependency tree (`common-lib` ← `
 | `BuildChangedProjectsFunctionalTest.kt` | `buildChangedProjects` |
 | `MonorepoPluginConfigurationTest.kt` | `printChangedProjects` (configuration/exclude scenarios) |
 | `ReleaseTaskFunctionalTest.kt` | `release` (per-subproject) |
-| `CreateReleaseBranchesFunctionalTest.kt` | `createReleaseBranches` |
+| `CreateReleaseBranchesForChangedProjectsFunctionalTest.kt` | `createReleaseBranchesForChangedProjects` |
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Builds all affected projects (including transitive dependents). Useful for PR va
 ./gradlew buildChangedProjects
 ```
 
-> **Note:** `buildChangedProjects` does not update the last-successful-build tag or create release branches. Use `createReleaseBranches` for post-merge CI workflows. `createReleaseBranches` depends on `buildChangedProjects`, so all affected projects are built first automatically.
+> **Note:** `buildChangedProjects` does not update the last-successful-build tag or create release branches. Use `createReleaseBranchesForChangedProjects` for post-merge CI workflows. `createReleaseBranchesForChangedProjects` depends on `buildChangedProjects`, so all affected projects are built first automatically.
 
 ### Releases
 
@@ -113,12 +113,12 @@ monorepo {
 }
 ```
 
-#### `createReleaseBranches`
+#### `createReleaseBranchesForChangedProjects`
 
 The CI post-merge task. Depends on `buildChangedProjects` to build all affected projects first, then creates release branches atomically for opted-in projects and updates the last-successful-build tag. Fails fast if the current branch is not `primaryBranch`.
 
 ```bash
-./gradlew createReleaseBranches
+./gradlew createReleaseBranchesForChangedProjects
 ```
 
 Release branches are created using a two-phase atomic approach: all branches are created locally first, then pushed together via `git push --atomic`. If any step fails, all local branches are rolled back and the tag is not updated.
@@ -210,7 +210,7 @@ Then build everything affected to verify it compiles before opening the PR:
 The PR is merged into `main` and CI triggers on the merge commit. The plugin compares HEAD against the `monorepo/last-successful-build` tag to find what changed since the last green build:
 
 ```bash
-./gradlew createReleaseBranches
+./gradlew createReleaseBranchesForChangedProjects
 ```
 
 `:shared-module` changed, so both apps are included via transitive impact. `:shared-module` itself is skipped because it isn't opted in to releases. The task builds all affected projects, creates release branches atomically, and updates the tag — all in one step.
@@ -251,7 +251,7 @@ The plugin detects it is on a release branch and applies a patch bump. Tag `rele
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `primaryBranch` | String | `"main"` | Main integration branch; used as fallback ref (`origin/{primaryBranch}`) when the tag doesn't exist, and as branch guard for `createReleaseBranches` |
+| `primaryBranch` | String | `"main"` | Main integration branch; used as fallback ref (`origin/{primaryBranch}`) when the tag doesn't exist, and as branch guard for `createReleaseBranchesForChangedProjects` |
 
 ### `monorepo { build { } }`
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -145,7 +145,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
 
         // ── Aggregate release task ────────────────────────────────────────────
 
-        project.tasks.register("createReleaseBranches").configure {
+        project.tasks.register("createReleaseBranchesForChangedProjects").configure {
             group = RELEASE_TASK_GROUP
             description = "Creates release branches for changed projects"
             dependsOn("buildChangedProjects")
@@ -167,7 +167,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
                 val currentBranch = releaseExecutor.currentBranch()
                 if (currentBranch != ext.primaryBranch) {
                     throw GradleException(
-                        "createReleaseBranches must run on '${ext.primaryBranch}', " +
+                        "createReleaseBranchesForChangedProjects must run on '${ext.primaryBranch}', " +
                         "but the current branch is '$currentBranch'."
                     )
                 }
@@ -227,7 +227,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
      * Resolves the base ref for change detection.
      *
      * The baseline depends on which task the user requested:
-     * - If `createReleaseBranches` is requested (CI release build) →
+     * - If `createReleaseBranchesForChangedProjects` is requested (CI release build) →
      *   fetch the last-successful-build tag from origin (many CI environments
      *   do not fetch tags by default), then use it; if the tag does not exist,
      *   return null so all projects are treated as changed (the first build on
@@ -245,8 +245,8 @@ class MonorepoBuildReleasePlugin @Inject constructor(
 
         val requestedTasks = project.gradle.startParameter.taskNames
         val isReleaseRun = requestedTasks.any { taskName ->
-            taskName == "createReleaseBranches" ||
-            taskName == ":createReleaseBranches"
+            taskName == "createReleaseBranchesForChangedProjects" ||
+            taskName == ":createReleaseBranchesForChangedProjects"
         }
 
         if (isReleaseRun) {
@@ -286,7 +286,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
         val changeDetectionTasks = setOf(
             "printChangedProjects", ":printChangedProjects",
             "buildChangedProjects", ":buildChangedProjects",
-            "createReleaseBranches", ":createReleaseBranches"
+            "createReleaseBranchesForChangedProjects", ":createReleaseBranchesForChangedProjects"
         )
         return project.gradle.startParameter.taskNames.any { it in changeDetectionTasks }
     }

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoExtension.kt
@@ -27,7 +27,7 @@ open class MonorepoExtension {
      * The primary integration branch name (e.g. "main", "master", "develop").
      * Used as fallback ref (`origin/<primaryBranch>`) when the last-successful-build tag
      * doesn't exist, and as the branch guard for CI tasks like
-     * `createReleaseBranches`.
+     * `createReleaseBranchesForChangedProjects`.
      */
     var primaryBranch: String = "main"
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
@@ -11,7 +11,7 @@ open class MonorepoBuildExtension {
      * The tag name that the plugin reads from and writes to for tracking the
      * last successful build.
      *
-     * This tag is only used as baseline when the `createReleaseBranches`
+     * This tag is only used as baseline when the `createReleaseBranchesForChangedProjects`
      * task is requested (CI release builds). Before checking for the tag locally,
      * the plugin fetches it from origin to ensure the local copy is current
      * (many CI environments do not fetch tags by default). For all other tasks
@@ -36,7 +36,7 @@ open class MonorepoBuildExtension {
      * The ref that was actually used for change detection, or null when no baseline exists
      * (all projects treated as changed). Set internally after ref resolution.
      *
-     * For CI release builds (`createReleaseBranches`), this is typically
+     * For CI release builds (`createReleaseBranchesForChangedProjects`), this is typically
      * the [lastSuccessfulBuildTag]. For all other tasks, this is `origin/{primaryBranch}`.
      * Null when the chosen ref is not available.
      */

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesForChangedProjectsFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesForChangedProjectsFunctionalTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.TaskOutcome
 
-class CreateReleaseBranchesFunctionalTest : FunSpec({
+class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
 
     val testListener = extension(ReleaseTestProjectListener())
 
@@ -23,7 +23,7 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.createBranch("feature/something")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranches")
+        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
 
         // then
         result.output shouldContain "must run on 'main'"
@@ -44,13 +44,13 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then: the full dependency chain executed
         result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.task(":app:build")?.outcome shouldBe TaskOutcome.SUCCESS
         result.task(":lib:build")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -65,10 +65,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         val headCommit = project.headCommit()
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then: tag still updated (idempotent) even when no changes detected
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "No projects have changed"
         project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
         project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
@@ -88,10 +88,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         val headCommit = project.headCommit()
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
         project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
@@ -110,10 +110,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldContain "release/lib/v0.1.x"
     }
@@ -145,10 +145,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         // If using origin/main: nothing changed (diff C..C) → no release branches
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then: proves the tag is used — app has a release branch
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "Change detection baseline: monorepo/last-successful-build ("
         project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
@@ -183,10 +183,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         // If origin/main is used: nothing changed (diff C..C) → no release branches
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then: proves the tag was fetched from remote and used as baseline
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
 
@@ -203,7 +203,7 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.setRemoteUrl("origin", "/nonexistent/path/to/repo")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranches")
+        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
 
         // then: build fails with a clear error instead of silently falling back
         result.output shouldContain "Failed to fetch tag"
@@ -225,10 +225,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
     }
@@ -253,10 +253,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v1.0.x"
         project.remoteBranches() shouldContain "release/lib/v1.0.x"
     }
@@ -278,7 +278,7 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.checkoutBranch("main")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranches")
+        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
 
         // then: task fails; neither branch pushed; tag not updated
         result.output shouldContain "already exists locally"
@@ -318,7 +318,7 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         project.commitAll("Change app")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranches")
+        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
 
         // then: tag should NOT have moved
         result.output shouldContain "Simulated build failure"
@@ -335,10 +335,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then: no baseline, all projects treated as changed, release branches created
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no baseline exists"
         result.output shouldContain "Change detection baseline: none (all projects treated as changed)"
         project.remoteBranches() shouldContain "release/app/v0.1.x"
@@ -383,10 +383,10 @@ class CreateReleaseBranchesFunctionalTest : FunSpec({
         val headCommit = project.headCommit()
 
         // when
-        val result = project.runTask("createReleaseBranches")
+        val result = project.runTask("createReleaseBranchesForChangedProjects")
 
         // then: tag still updated even though no release branches were created
-        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no release branches to create"
         project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
         project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/BuildChangedProjectsTaskTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/BuildChangedProjectsTaskTest.kt
@@ -21,7 +21,7 @@ class BuildChangedProjectsTaskTest : FunSpec({
         task?.description shouldBe "Builds only the projects that have been affected by changes"
     }
 
-    test("createReleaseBranches task should be registered") {
+    test("createReleaseBranchesForChangedProjects task should be registered") {
         // given
         val project = ProjectBuilder.builder().build()
 
@@ -29,7 +29,7 @@ class BuildChangedProjectsTaskTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-release-plugin")
 
         // then
-        val task = project.tasks.findByName("createReleaseBranches")
+        val task = project.tasks.findByName("createReleaseBranchesForChangedProjects")
         task shouldNotBe null
         task?.group shouldBe "monorepo-release"
         task?.description shouldBe "Creates release branches for changed projects"


### PR DESCRIPTION
## Summary
- Renames the `createReleaseBranches` task to `createReleaseBranchesForChangedProjects` to disambiguate from a planned `createReleaseBranch` task that will create a release branch for a specific app regardless of change detection
- Updates task registration, error messages, `isReleaseRun` detection, `isChangeDetectionRun` detection, KDoc references, unit/functional tests, README, and CLAUDE.md

## Test plan
- [x] All unit tests pass (`./gradlew unitTest`)
- [x] All functional tests pass (`./gradlew functionalTest`)
- [x] Full `./gradlew check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)