### PR TITLE
fix: log relative path for release-version.txt

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/ReleaseTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/ReleaseTask.kt
@@ -131,7 +131,8 @@ abstract class ReleaseTask : DefaultTask() {
         val versionFile = buildDir.file("release-version.txt").get().asFile
         versionFile.parentFile.mkdirs()
         versionFile.writeText(nextVersion.toString())
-        logger.lifecycle("Wrote release version to: ${versionFile.absolutePath}")
+        val relativePath = project.rootDir.toPath().relativize(versionFile.toPath())
+        logger.lifecycle("Wrote release version to: $relativePath")
     }
 
     private fun resolveScope(): Scope {


### PR DESCRIPTION
## Summary

- Change the release task to log a relative path (e.g., `app/build/release-version.txt`) instead of an absolute path when writing the release version file
- Makes log output more readable and portable when debugging CI pipeline setup

## Test plan

- [x] `ReleaseTaskFunctionalTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)