### PR TITLE
chore: downgrade to Gradle 8.5 for broader compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,9 +15,9 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    testImplementation("io.kotest:kotest-runner-junit5:6.1.4")
-    testImplementation("io.kotest:kotest-assertions-core:6.1.4")
-    testImplementation("io.kotest:kotest-property:6.1.4")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+    testImplementation("io.kotest:kotest-property:5.9.1")
 }
 
 // Configure source sets for unit, integration, and functional tests
@@ -56,20 +56,21 @@ sourceSets {
 // Add dependencies for the test source sets
 dependencies {
     // Unit test dependencies
-    add("unitTestImplementation", "io.kotest:kotest-runner-junit5:6.1.4")
-    add("unitTestImplementation", "io.kotest:kotest-assertions-core:6.1.4")
-    add("unitTestImplementation", "io.kotest:kotest-property:6.1.4")
-    add("unitTestImplementation", "io.mockk:mockk:1.14.9")
+    add("unitTestImplementation", "io.kotest:kotest-runner-junit5:5.9.1")
+    add("unitTestImplementation", "io.kotest:kotest-assertions-core:5.9.1")
+    add("unitTestImplementation", "io.kotest:kotest-property:5.9.1")
+    add("unitTestImplementation", "io.kotest:kotest-framework-datatest:5.9.1")
+    add("unitTestImplementation", "io.mockk:mockk:1.13.13")
 
     // Integration test dependencies
-    add("integrationTestImplementation", "io.kotest:kotest-runner-junit5:6.1.4")
-    add("integrationTestImplementation", "io.kotest:kotest-assertions-core:6.1.4")
-    add("integrationTestImplementation", "io.mockk:mockk:1.14.9")
+    add("integrationTestImplementation", "io.kotest:kotest-runner-junit5:5.9.1")
+    add("integrationTestImplementation", "io.kotest:kotest-assertions-core:5.9.1")
+    add("integrationTestImplementation", "io.mockk:mockk:1.13.13")
 
     // Functional test dependencies
     add("functionalTestImplementation", gradleTestKit())
-    add("functionalTestImplementation", "io.kotest:kotest-runner-junit5:6.1.4")
-    add("functionalTestImplementation", "io.kotest:kotest-assertions-core:6.1.4")
+    add("functionalTestImplementation", "io.kotest:kotest-runner-junit5:5.9.1")
+    add("functionalTestImplementation", "io.kotest:kotest-assertions-core:5.9.1")
 }
 
 // Register unit test task

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -20,17 +20,13 @@ import io.github.doughawley.monorepo.release.git.GitTagScanner
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.logging.Logger
-import javax.inject.Inject
 
 /**
  * Gradle plugin that combines change detection and per-project versioned tagging
  * for Gradle monorepos.
  */
-class MonorepoBuildReleasePlugin @Inject constructor(
-    private val buildFeatures: BuildFeatures
-) : Plugin<Project> {
+class MonorepoBuildReleasePlugin : Plugin<Project> {
 
     private companion object {
         const val BUILD_TASK_GROUP = "monorepo"
@@ -38,7 +34,7 @@ class MonorepoBuildReleasePlugin @Inject constructor(
     }
 
     override fun apply(project: Project) {
-        if (buildFeatures.configurationCache.requested.getOrElse(false)) {
+        if (project.gradle.startParameter.isConfigurationCacheRequested) {
             throw GradleException(
                 "monorepo-build-release-plugin is incompatible with the Gradle configuration cache " +
                 "because it executes git commands during the configuration phase. " +

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataFactory.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataFactory.kt
@@ -120,7 +120,8 @@ class ProjectMetadataFactory(private val logger: Logger) {
                         // object with endorseStrictVersions() and the Category.REGULAR_PLATFORM
                         // attribute set on it — it does not wrap it in a different type.
                         if (dep is ProjectDependency) {
-                            dependencies.add(dep.path)
+                            @Suppress("DEPRECATION")
+                            dependencies.add(dep.dependencyProject.path)
                         }
                     }
                 } catch (e: Exception) {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectListener.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectListener.kt
@@ -2,7 +2,7 @@ package io.github.doughawley.monorepo.build.functional
 
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
+import io.kotest.core.test.TestResult
 import java.io.File
 
 /**
@@ -59,7 +59,7 @@ class TestProjectListener : TestListener {
 
     override suspend fun beforeEach(testCase: TestCase) {
         // Sanitize test name for use in file paths (Windows doesn't allow : < > " | ? *)
-        val sanitizedTestName = testCase.name.name.replace(Regex("[:<>\"|?*/]"), "-")
+        val sanitizedTestName = testCase.name.testName.replace(Regex("[:<>\"|?*/]"), "-")
         val tempDir = kotlin.io.path.createTempDirectory("monorepo-test-$sanitizedTestName").toFile()
         currentTestDir = tempDir
     }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/StandardReleaseTestProject.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/StandardReleaseTestProject.kt
@@ -2,7 +2,7 @@ package io.github.doughawley.monorepo.release.functional
 
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
+import io.kotest.core.test.TestResult
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
@@ -429,7 +429,7 @@ class ReleaseTestProjectListener : TestListener {
     }
 
     override suspend fun beforeEach(testCase: TestCase) {
-        val sanitizedTestName = testCase.name.name.replace(Regex("[:<>\"|?*/]"), "-")
+        val sanitizedTestName = testCase.name.testName.replace(Regex("[:<>\"|?*/]"), "-")
         val tempDir = kotlin.io.path.createTempDirectory("release-test-$sanitizedTestName").toFile()
         currentTestDir = tempDir
     }

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/TempGitRepo.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/TempGitRepo.kt
@@ -2,7 +2,7 @@ package io.github.doughawley.monorepo.release.git
 
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
+import io.kotest.core.test.TestResult
 import java.io.File
 import java.nio.file.Files
 


### PR DESCRIPTION
## Summary

- Downgrade Gradle wrapper from 9.4.0 to 8.5 so the plugin doesn't force consumers to be on Gradle 9
- Replace Gradle 9-specific APIs with Gradle 8.5-compatible equivalents:
  - `BuildFeatures.configurationCache.requested` → `StartParameter.isConfigurationCacheRequested`
  - `ProjectDependency.path` → `ProjectDependency.dependencyProject.path`
- Downgrade test dependencies to Kotlin 1.9-compatible versions (Kotest 5.9.1, MockK 1.13.13)
- Fix Kotest 5.x API differences (`TestResult` import path, `TestName.testName`, separate `datatest` module)

## Test plan

- [x] All 88 tests pass (unit, integration, functional)
- [x] Configuration cache detection test passes with `StartParameter` API

🤖 Generated with [Claude Code](https://claude.com/claude-code)