### PR TITLE
refactor: shorten task names and unify task group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ A Gradle plugin (Kotlin) that optimizes CI/CD build times in multi-module projec
 To run a single test class, use the `--tests` filter:
 ```bash
 ./gradlew unitTest --tests "io.github.doughawley.monorepo.build.git.GitChangedFilesDetectorTest"
-./gradlew functionalTest --tests "io.github.doughawley.monorepo.build.functional.PrintChangedProjectsFunctionalTest"
+./gradlew functionalTest --tests "io.github.doughawley.monorepo.build.functional.PrintChangedFunctionalTest"
 ```
 
 After running tests, check results in `build/reports/tests/*/index.html` or `build/test-results/*/*.xml` for details.
@@ -73,11 +73,11 @@ The functional tests use a standard 5-module dependency tree (`common-lib` ← `
 
 | File | Task |
 |---|---|
-| `PrintChangedProjectsFunctionalTest.kt` | `printChangedProjects` |
-| `BuildChangedProjectsFunctionalTest.kt` | `buildChangedProjects` |
-| `MonorepoPluginConfigurationTest.kt` | `printChangedProjects` (configuration/exclude scenarios) |
+| `PrintChangedFunctionalTest.kt` | `printChanged` |
+| `BuildChangedFunctionalTest.kt` | `buildChanged` |
+| `MonorepoPluginConfigurationTest.kt` | `printChanged` (configuration/exclude scenarios) |
 | `ReleaseTaskFunctionalTest.kt` | `release` (per-subproject) |
-| `CreateReleaseBranchesForChangedProjectsFunctionalTest.kt` | `createReleaseBranchesForChangedProjects` |
+| `CreateReleaseBranchesFunctionalTest.kt` | `createReleaseBranches` |
 
 ## Code Style
 

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -35,7 +35,7 @@ Issues identified during code review. Severity: **high**, **medium**, **low**.
 - **Issue**: `projectDir.relativeTo(rootDir)` throws if a subproject's directory is outside the root, with no clear error message for the user.
 - **Status**: Fixed in `fix-medium-severity-issues` — wrapped in try-catch that rethrows with a descriptive message including the offending project path and directories.
 
-### 6. Confusing error message when metadata check fails in `buildChangedProjects`
+### 6. Confusing error message when metadata check fails in `buildChanged`
 - **File**: `src/main/kotlin/.../MonorepoChangedProjectsPlugin.kt` (lines 86–111)
 - **Issue**: If metadata computation was skipped or failed silently, the resulting `IllegalStateException` doesn't surface the root cause.
 - **Status**: Fixed in `fix-medium-severity-issues` — error message now lists likely causes and directs the user to re-run with `--info` or `--debug`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,7 +340,7 @@ mkdir test-project
 cd test-project
 git init
 # Create build.gradle.kts with your plugin
-./gradlew printChangedProjects
+./gradlew printChanged
 ```
 
 ### Debugging
@@ -348,7 +348,7 @@ git init
 Run Gradle with debug logging:
 
 ```bash
-./gradlew printChangedProjects --debug
+./gradlew printChanged --debug
 ```
 
 Run tests with IntelliJ IDEA debugger:

--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -197,7 +197,7 @@ monorepo {
 ```
 
 ```bash
-./gradlew printChangedProjects
+./gradlew printChanged
 ```
 
 ### Update Badges (Optional)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ monorepo {
 
 The plugin detects changes by comparing HEAD against a baseline ref. The baseline depends on the task:
 
-- **CI release builds** (`createReleaseBranchesForChangedProjects`): uses the `lastSuccessfulBuildTag`. If the tag doesn't exist (e.g., first run), all projects are treated as changed.
+- **CI release builds** (`createReleaseBranches`): uses the `lastSuccessfulBuildTag`. If the tag doesn't exist (e.g., first run), all projects are treated as changed.
 - **Dev and PR builds** (all other tasks): uses `origin/{primaryBranch}`. If the remote branch isn't available, all projects are treated as changed.
 
 Individual subprojects can declare their own exclude patterns using the `monorepoProject` extension. Patterns are matched against paths relative to the subproject directory and are applied after global `excludePatterns`.
@@ -62,23 +62,23 @@ monorepoProject {
 
 ### Tasks
 
-#### `printChangedProjects`
+#### `printChanged`
 
 Prints a human-readable report of which projects have changed and which are transitively affected.
 
 ```bash
-./gradlew printChangedProjects
+./gradlew printChanged
 ```
 
-#### `buildChangedProjects`
+#### `buildChanged`
 
 Builds all affected projects (including transitive dependents). Useful for PR validation and local development.
 
 ```bash
-./gradlew buildChangedProjects
+./gradlew buildChanged
 ```
 
-> **Note:** `buildChangedProjects` does not update the last-successful-build tag or create release branches. Use `createReleaseBranchesForChangedProjects` for post-merge CI workflows. `createReleaseBranchesForChangedProjects` depends on `buildChangedProjects`, so all affected projects are built first automatically.
+> **Note:** `buildChanged` does not update the last-successful-build tag or create release branches. Use `createReleaseBranches` for post-merge CI workflows. `createReleaseBranches` depends on `buildChanged`, so all affected projects are built first automatically.
 
 ### Releases
 
@@ -120,12 +120,12 @@ monorepo {
 
 ### Tasks
 
-#### `createReleaseBranchesForChangedProjects`
+#### `createReleaseBranches`
 
-The CI post-merge task. Depends on `buildChangedProjects` to build all affected projects first, then creates release branches atomically for opted-in projects and updates the last-successful-build tag. Fails fast if the current branch is not `primaryBranch`.
+The CI post-merge task. Depends on `buildChanged` to build all affected projects first, then creates release branches atomically for opted-in projects and updates the last-successful-build tag. Fails fast if the current branch is not `primaryBranch`.
 
 ```bash
-./gradlew createReleaseBranchesForChangedProjects
+./gradlew createReleaseBranches
 ```
 
 Release branches are created using a two-phase atomic approach: all branches are created locally first, then pushed together via `git push --atomic`. If any step fails, all local branches are rolled back and the tag is not updated.
@@ -204,7 +204,7 @@ monorepoProject {
 A developer has modified `:shared-module` on a feature branch. To see what's affected before opening a PR:
 
 ```bash
-./gradlew printChangedProjects
+./gradlew printChanged
 ```
 
 ```
@@ -221,7 +221,7 @@ Changed projects:
 Then build everything affected to verify it compiles before opening the PR:
 
 ```bash
-./gradlew buildChangedProjects
+./gradlew buildChanged
 ```
 
 ### Releasing from main
@@ -229,7 +229,7 @@ Then build everything affected to verify it compiles before opening the PR:
 The PR is merged into `main` and CI triggers on the merge commit. The plugin compares HEAD against the `monorepo/last-successful-build` tag to find what changed since the last green build:
 
 ```bash
-./gradlew createReleaseBranchesForChangedProjects
+./gradlew createReleaseBranches
 ```
 
 `:shared-module` changed, so both apps are included via transitive impact. `:shared-module` itself is skipped because it isn't opted in to releases. The task builds all affected projects, creates release branches atomically, and updates the tag — all in one step.
@@ -277,14 +277,14 @@ The plugin pushes git refs (release branches and the last-successful-build tag) 
 
 #### Pipeline for `main` (post-merge builds)
 
-Configure your main branch pipeline to run `createReleaseBranchesForChangedProjects` on pushes to `main`:
+Configure your main branch pipeline to run `createReleaseBranches` on pushes to `main`:
 
 ```yaml
 steps:
   - name: build-and-release
     image: gradle:jdk17
     commands:
-      - ./gradlew createReleaseBranchesForChangedProjects
+      - ./gradlew createReleaseBranches
 
 metadata:
   template: false
@@ -294,7 +294,7 @@ ruleset:
   branch: main
 ```
 
-> **Warning:** The `createReleaseBranchesForChangedProjects` task force-pushes the `monorepo/last-successful-build` tag on every run. If your pipeline triggers on **all** tag events, this will create an infinite loop: task pushes tag → Vela triggers build → task pushes tag → repeat.
+> **Warning:** The `createReleaseBranches` task force-pushes the `monorepo/last-successful-build` tag on every run. If your pipeline triggers on **all** tag events, this will create an infinite loop: task pushes tag → Vela triggers build → task pushes tag → repeat.
 >
 > Ensure your tag-triggered pipelines filter to version-pattern tags only (e.g., `v*`), not all tags.
 
@@ -317,7 +317,7 @@ ruleset:
   branch: release/*
 ```
 
-> **Warning:** The release branches pushed by `createReleaseBranchesForChangedProjects` will trigger this pipeline. Make sure the release pipeline does **not** also run `createReleaseBranchesForChangedProjects`, or you will get recursive triggers.
+> **Warning:** The release branches pushed by `createReleaseBranches` will trigger this pipeline. Make sure the release pipeline does **not** also run `createReleaseBranches`, or you will get recursive triggers.
 
 #### Tag-triggered pipelines
 
@@ -349,10 +349,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - run: ./gradlew createReleaseBranchesForChangedProjects
+      - run: ./gradlew createReleaseBranches
 ```
 
-> **Warning:** GitHub Actions does **not** trigger workflows from pushes made with the default `GITHUB_TOKEN`. This is a deliberate safeguard against recursive workflows, but it means the release branches created by `createReleaseBranchesForChangedProjects` will **not** automatically trigger your release workflow.
+> **Warning:** GitHub Actions does **not** trigger workflows from pushes made with the default `GITHUB_TOKEN`. This is a deliberate safeguard against recursive workflows, but it means the release branches created by `createReleaseBranches` will **not** automatically trigger your release workflow.
 >
 > To trigger release branch workflows, use one of these approaches:
 > 1. **GitHub App token** — use a GitHub App installation token (e.g., via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)) instead of `GITHUB_TOKEN` for the checkout step. Pushes made with this token will trigger downstream workflows.
@@ -388,7 +388,7 @@ This workflow will only trigger if pushes to release branches are made with a to
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `primaryBranch` | String | `"main"` | Main integration branch; used as baseline ref (`origin/{primaryBranch}`) for dev and PR builds, and as branch guard for `createReleaseBranchesForChangedProjects` |
+| `primaryBranch` | String | `"main"` | Main integration branch; used as baseline ref (`origin/{primaryBranch}`) for dev and PR builds, and as branch guard for `createReleaseBranches` |
 
 ### `monorepo { build { } }`
 
@@ -438,7 +438,7 @@ This can happen if:
 Solution:
 ```bash
 git fetch origin
-./gradlew printChangedProjects
+./gradlew printChanged
 ```
 
 ### No projects detected despite changes
@@ -446,7 +446,7 @@ git fetch origin
 Check your `excludePatterns` configuration - you may be inadvertently excluding files. Enable logging to see what files are being detected:
 
 ```bash
-./gradlew printChangedProjects --info
+./gradlew printChanged --info
 ```
 
 ### Root project always shows as changed

--- a/TEST_STRUCTURE.md
+++ b/TEST_STRUCTURE.md
@@ -46,8 +46,8 @@ Functional tests verify end-to-end functionality:
 - Tests real-world scenarios with actual git operations
 
 **Current Functional Tests:**
-- `PrintChangedProjectsFunctionalTest.kt` - Tests the `printChangedProjects` task
-- `BuildChangedProjectsFunctionalTest.kt` - Tests the `buildChangedProjects` task
+- `PrintChangedFunctionalTest.kt` - Tests the `printChanged` task
+- `BuildChangedFunctionalTest.kt` - Tests the `buildChanged` task
 - `MonorepoPluginConfigurationTest.kt` - Configuration and exclude pattern scenarios
 - `MonorepoPluginHierarchyNodeFunctionalTest.kt` - Hierarchy node detection
 - `MonorepoPluginNestedProjectFunctionalTest.kt` - Nested project detection

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -29,8 +29,7 @@ import org.gradle.api.logging.Logger
 class MonorepoBuildReleasePlugin : Plugin<Project> {
 
     private companion object {
-        const val BUILD_TASK_GROUP = "monorepo"
-        const val RELEASE_TASK_GROUP = "monorepo-release"
+        const val TASK_GROUP = "monorepo"
     }
 
     override fun apply(project: Project) {
@@ -101,7 +100,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
                         }
                     }
 
-                    wireDependsOn(project, "buildChangedProjects", rootBuildExtension.allAffectedProjects)
+                    wireDependsOn(project, "buildChanged", rootBuildExtension.allAffectedProjects)
                     rootBuildExtension.metadataComputed = true
                     project.logger.debug("Changed project metadata computed successfully in configuration phase")
                 } catch (e: GradleException) {
@@ -117,14 +116,14 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
 
         // ── Build tasks ──────────────────────────────────────────────────────────
 
-        project.tasks.register("printChangedProjects", PrintChangedProjectsTask::class.java).configure {
-            group = BUILD_TASK_GROUP
+        project.tasks.register("printChanged", PrintChangedProjectsTask::class.java).configure {
+            group = TASK_GROUP
             description = "Detects which projects have changed based on git history"
             buildExtension = rootBuildExtension
         }
 
-        project.tasks.register("buildChangedProjects").configure {
-            group = BUILD_TASK_GROUP
+        project.tasks.register("buildChanged").configure {
+            group = TASK_GROUP
             description = "Builds only the projects that have been affected by changes"
             val ext = rootBuildExtension
             doLast {
@@ -141,10 +140,10 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
 
         // ── Aggregate release task ────────────────────────────────────────────
 
-        project.tasks.register("createReleaseBranchesForChangedProjects").configure {
-            group = RELEASE_TASK_GROUP
+        project.tasks.register("createReleaseBranches").configure {
+            group = TASK_GROUP
             description = "Creates release branches for changed projects"
-            dependsOn("buildChangedProjects")
+            dependsOn("buildChanged")
             val buildExt = rootBuildExtension
             val releaseExt = rootReleaseExtension
             val ext = rootExtension
@@ -163,7 +162,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
                 val currentBranch = releaseExecutor.currentBranch()
                 if (currentBranch != ext.primaryBranch) {
                     throw GradleException(
-                        "createReleaseBranchesForChangedProjects must run on '${ext.primaryBranch}', " +
+                        "createReleaseBranches must run on '${ext.primaryBranch}', " +
                         "but the current branch is '$currentBranch'."
                     )
                 }
@@ -223,7 +222,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
      * Resolves the base ref for change detection.
      *
      * The baseline depends on which task the user requested:
-     * - If `createReleaseBranchesForChangedProjects` is requested (CI release build) →
+     * - If `createReleaseBranches` is requested (CI release build) →
      *   fetch the last-successful-build tag from origin (many CI environments
      *   do not fetch tags by default), then use it; if the tag does not exist,
      *   return null so all projects are treated as changed (the first build on
@@ -241,8 +240,8 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
 
         val requestedTasks = project.gradle.startParameter.taskNames
         val isReleaseRun = requestedTasks.any { taskName ->
-            taskName == "createReleaseBranchesForChangedProjects" ||
-            taskName == ":createReleaseBranchesForChangedProjects"
+            taskName == "createReleaseBranches" ||
+            taskName == ":createReleaseBranches"
         }
 
         if (isReleaseRun) {
@@ -280,9 +279,9 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
      */
     private fun isChangeDetectionRun(project: Project): Boolean {
         val changeDetectionTasks = setOf(
-            "printChangedProjects", ":printChangedProjects",
-            "buildChangedProjects", ":buildChangedProjects",
-            "createReleaseBranchesForChangedProjects", ":createReleaseBranchesForChangedProjects"
+            "printChanged", ":printChanged",
+            "buildChanged", ":buildChanged",
+            "createReleaseBranches", ":createReleaseBranches"
         )
         return project.gradle.startParameter.taskNames.any { it in changeDetectionTasks }
     }
@@ -403,12 +402,12 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
         val releaseExecutor = GitReleaseExecutor(sub.rootProject.rootDir, executor, sub.logger)
 
         val postRelease = sub.tasks.register("postRelease") {
-            group = RELEASE_TASK_GROUP
+            group = TASK_GROUP
             description = "Lifecycle hook: wire publish tasks here via finalizedBy"
         }
 
         val releaseTask = sub.tasks.register("release", ReleaseTask::class.java) {
-            group = RELEASE_TASK_GROUP
+            group = TASK_GROUP
             description = "Creates a versioned git tag for this project"
             this.rootExtension = rootExtension
             this.projectConfig = config

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoExtension.kt
@@ -27,7 +27,7 @@ open class MonorepoExtension {
      * The primary integration branch name (e.g. "main", "master", "develop").
      * Used as fallback ref (`origin/<primaryBranch>`) when the last-successful-build tag
      * doesn't exist, and as the branch guard for CI tasks like
-     * `createReleaseBranchesForChangedProjects`.
+     * `createReleaseBranches`.
      */
     var primaryBranch: String = "main"
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
@@ -11,11 +11,11 @@ open class MonorepoBuildExtension {
      * The tag name that the plugin reads from and writes to for tracking the
      * last successful build.
      *
-     * This tag is only used as baseline when the `createReleaseBranchesForChangedProjects`
+     * This tag is only used as baseline when the `createReleaseBranches`
      * task is requested (CI release builds). Before checking for the tag locally,
      * the plugin fetches it from origin to ensure the local copy is current
      * (many CI environments do not fetch tags by default). For all other tasks
-     * (`printChangedProjects`, `buildChangedProjects`), the plugin uses
+     * (`printChanged`, `buildChanged`), the plugin uses
      * `origin/{primaryBranch}` as the baseline instead.
      *
      * When the chosen ref does not exist, all projects are treated as changed.
@@ -36,7 +36,7 @@ open class MonorepoBuildExtension {
      * The ref that was actually used for change detection, or null when no baseline exists
      * (all projects treated as changed). Set internally after ref resolution.
      *
-     * For CI release builds (`createReleaseBranchesForChangedProjects`), this is typically
+     * For CI release builds (`createReleaseBranches`), this is typically
      * the [lastSuccessfulBuildTag]. For all other tasks, this is `origin/{primaryBranch}`.
      * Null when the chosen ref is not available.
      */

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
@@ -12,22 +12,22 @@ import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.TaskOutcome
 
 /**
- * Functional tests for the buildChangedProjects task.
+ * Functional tests for the buildChanged task.
  */
-class BuildChangedProjectsFunctionalTest : FunSpec({
+class BuildChangedFunctionalTest : FunSpec({
     val testProjectListener = extension(TestProjectListener())
 
-    test("buildChangedProjects task builds only affected projects") {
+    test("buildChanged task builds only affected projects") {
         // given
         val project = testProjectListener.createStandardProject()
         project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Modified")
         project.commitAll("Change common-lib")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContainAll setOf(
             Projects.COMMON_LIB,
@@ -38,35 +38,35 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
     }
 
-    test("buildChangedProjects builds only affected apps when module changes") {
+    test("buildChanged builds only affected apps when module changes") {
         // given
         val project = testProjectListener.createStandardProject()
         project.appendToFile(Files.MODULE1_SOURCE, "\n// Modified")
         project.commitAll("Change module1")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContainAll setOf(Projects.MODULE1, Projects.APP1)
         builtProjects shouldNotContain Projects.APP2
     }
 
-    test("buildChangedProjects reports no changes when nothing modified") {
+    test("buildChanged reports no changes when nothing modified") {
         // given
         val project = testProjectListener.createStandardProject()
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "No projects have changed - nothing to build"
     }
 
-    test("buildChangedProjects handles multiple independent app changes") {
+    test("buildChanged handles multiple independent app changes") {
         // given
         val project = testProjectListener.createStandardProject()
         project.appendToFile(Files.APP1_SOURCE, "\n// Modified A")
@@ -74,39 +74,39 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change both apps")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContainAll setOf(Projects.APP1, Projects.APP2)
     }
 
-    test("buildChangedProjects succeeds without running printChangedProjects") {
+    test("buildChanged succeeds without running printChanged") {
         // given
         val project = testProjectListener.createStandardProject()
         project.appendToFile(Files.MODULE2_SOURCE, "\n// Changed")
         project.commitAll("Change module2")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.task(":printChangedProjects") shouldBe null
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged") shouldBe null
     }
 
-    test("buildChangedProjects builds only leaf project when changed") {
+    test("buildChanged builds only leaf project when changed") {
         // given
         val project = testProjectListener.createStandardProject()
         project.appendToFile(Files.APP2_SOURCE, "\n// App changed")
         project.commitAll("Change app2")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContain Projects.APP2
         builtProjects shouldNotContain Projects.COMMON_LIB
@@ -115,17 +115,17 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         builtProjects shouldNotContain Projects.APP1
     }
 
-    test("buildChangedProjects builds projects affected by BOM changes") {
+    test("buildChanged builds projects affected by BOM changes") {
         // given
         val project = testProjectListener.createStandardProject()
         project.appendToFile(Files.PLATFORM_BUILD, "\n// BOM version bump")
         project.commitAll("Bump BOM version")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val builtProjects = result.extractBuiltProjects()
         builtProjects shouldContainAll setOf(
             Projects.PLATFORM,
@@ -144,10 +144,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Update BOM")
 
         // when
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 6
         changedProjects shouldContainAll setOf(
@@ -171,10 +171,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Update BOM and common-lib")
 
         // when
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 6
         changedProjects shouldContainAll setOf(
@@ -187,7 +187,7 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
     }
 
-    test("buildChangedProjects logs the change detection baseline") {
+    test("buildChanged logs the change detection baseline") {
         // given
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -198,16 +198,16 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Modify app2")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "Change detection baseline: origin/main ("
     }
 
     // --- origin/main baseline scenarios ---
 
-    test("buildChangedProjects uses origin/main as baseline and detects direct change") {
+    test("buildChanged uses origin/main as baseline and detects direct change") {
         // given
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -218,17 +218,17 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Modify app2")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val built = result.extractBuiltProjects()
         built shouldContain Projects.APP2
         built shouldNotContain Projects.COMMON_LIB
         built shouldNotContain Projects.MODULE1
     }
 
-    test("buildChangedProjects uses origin/main as baseline and detects transitive dependents") {
+    test("buildChanged uses origin/main as baseline and detects transitive dependents") {
         // given
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -239,10 +239,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Modify common-lib")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val built = result.extractBuiltProjects()
         built shouldContainAll setOf(
             Projects.COMMON_LIB,
@@ -253,7 +253,7 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
     }
 
-    test("buildChangedProjects reports no changes when nothing changed since origin/main") {
+    test("buildChanged reports no changes when nothing changed since origin/main") {
         // given: origin/main at HEAD, no changes
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -261,15 +261,15 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "No projects have changed - nothing to build"
     }
 
-    test("buildChangedProjects ignores last-successful-build tag and uses origin/main") {
-        // given: tag exists but buildChangedProjects should use origin/main instead
+    test("buildChanged ignores last-successful-build tag and uses origin/main") {
+        // given: tag exists but buildChanged should use origin/main instead
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
             withRemote = true
@@ -286,16 +286,16 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change module1")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then: uses origin/main (initial commit), so both changes are detected
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val built = result.extractBuiltProjects()
         built shouldContain Projects.APP2
         built shouldContain Projects.MODULE1
     }
 
-    test("buildChangedProjects treats all projects as changed when no baseline is available") {
+    test("buildChanged treats all projects as changed when no baseline is available") {
         // given: project without remote and no tag
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -303,10 +303,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         )
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then: no origin/main — no baseline exists
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no baseline"
         result.output shouldContain "Change detection baseline: none"
         val built = result.extractBuiltProjects()
@@ -315,8 +315,8 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         built shouldContain Projects.COMMON_LIB
     }
 
-    test("buildChangedProjects does not update the last-successful-build tag") {
-        // given: tag created by createAndInitialize, make a change, run buildChangedProjects
+    test("buildChanged does not update the last-successful-build tag") {
+        // given: tag created by createAndInitialize, make a change, run buildChanged
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
             withRemote = true
@@ -327,10 +327,10 @@ class BuildChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change app2")
 
         // when
-        val result = project.runTask("buildChangedProjects")
+        val result = project.runTask("buildChanged")
 
         // then: tag should still point at the original commit
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val built = result.extractBuiltProjects()
         built shouldContain Projects.APP2
 

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
@@ -29,10 +29,10 @@ class MonorepoPluginConfigurationTest : FunSpec({
         // when: a file matching the :api exclude pattern is created (untracked)
         project.createNewFile("api/generated/Code.kt", "// generated code")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then: :api is not considered changed because the only changed file is excluded
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldNotContain ":api"
     }
@@ -54,10 +54,10 @@ class MonorepoPluginConfigurationTest : FunSpec({
         project.createNewFile("api/generated/Code.kt", "// generated code")
         project.createNewFile("core/generated/Stub.kt", "// generated stub")
 
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then: :api is excluded (pattern matches), :core is detected (no pattern)
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldNotContain ":api"
         changedProjects shouldContain ":core"
@@ -68,7 +68,7 @@ class MonorepoPluginConfigurationTest : FunSpec({
         val project = testProjectListener.createStandardProject()
 
         // when: a task is run with --configuration-cache enabled
-        val result = project.runTaskAndFail("printChangedProjects", "--configuration-cache")
+        val result = project.runTaskAndFail("printChanged", "--configuration-cache")
 
         // then: the build fails with a clear incompatibility message pointing to the fix
         result.output shouldContain "monorepo-build-release-plugin is incompatible with the Gradle configuration cache"

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginHierarchyNodeFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginHierarchyNodeFunctionalTest.kt
@@ -22,10 +22,10 @@ class MonorepoPluginHierarchyNodeFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.APP1_SOURCE, "\n// Modified")
         project.commitAll("Change app1")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val directlyChanged = result.extractDirectlyChangedProjects()
         directlyChanged shouldContain Projects.APP1
         directlyChanged shouldNotContain ":apps"
@@ -38,10 +38,10 @@ class MonorepoPluginHierarchyNodeFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.MODULE1_SOURCE, "\n// Modified")
         project.commitAll("Change module1")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContain Projects.MODULE1
         changed shouldContain Projects.APP1
@@ -57,10 +57,10 @@ class MonorepoPluginHierarchyNodeFunctionalTest : FunSpec({
         project.appendToFile(Files.APP2_SOURCE, "\n// Modified")
         project.appendToFile(Files.MODULE2_SOURCE, "\n// Modified")
         project.commitAll("Change app2 and module2")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val directlyChanged = result.extractDirectlyChangedProjects()
         directlyChanged shouldContain Projects.APP2
         directlyChanged shouldContain Projects.MODULE2
@@ -77,10 +77,10 @@ class MonorepoPluginHierarchyNodeFunctionalTest : FunSpec({
             "modules/module2/src/main/kotlin/com/example/NewFeature.kt",
             "package com.example\nclass NewFeature"
         )
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val directlyChanged = result.extractDirectlyChangedProjects()
         directlyChanged shouldContain Projects.MODULE2
         directlyChanged shouldNotContain ":modules"
@@ -105,10 +105,10 @@ class MonorepoPluginHierarchyNodeFunctionalTest : FunSpec({
             "\n// Modified"
         )
         project.commitAll("Change billing impl")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val directlyChanged = result.extractDirectlyChangedProjects()
         directlyChanged shouldContain ":services:billing:impl"
         directlyChanged shouldNotContain ":services"

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginNestedProjectFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginNestedProjectFunctionalTest.kt
@@ -34,10 +34,10 @@ class MonorepoPluginNestedProjectFunctionalTest : FunSpec({
         // when
         project.appendToFile("services/billing/api/src/main/kotlin/com/example/Api.kt", "\n// Modified")
         project.commitAll("Change billing api")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContain ":services:billing:api"
     }
@@ -49,10 +49,10 @@ class MonorepoPluginNestedProjectFunctionalTest : FunSpec({
         // when
         project.appendToFile("services/billing/api/src/main/kotlin/com/example/Api.kt", "\n// Modified")
         project.commitAll("Change billing api")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContainAll setOf(
             ":services:billing:api",
@@ -69,10 +69,10 @@ class MonorepoPluginNestedProjectFunctionalTest : FunSpec({
         // when
         project.appendToFile("services/payments/gateway/src/main/kotlin/com/example/Gateway.kt", "\n// Modified")
         project.commitAll("Change payments gateway")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContainAll setOf(":services:payments:gateway", ":apps:web")
         changed shouldNotContain ":services:billing:api"
@@ -86,10 +86,10 @@ class MonorepoPluginNestedProjectFunctionalTest : FunSpec({
         // when
         project.appendToFile("services/billing/impl/src/main/kotlin/com/example/Impl.kt", "\n// Modified")
         project.commitAll("Change billing impl")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe org.gradle.testkit.runner.TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldBe setOf(":services:billing:impl")
     }
@@ -101,7 +101,7 @@ class MonorepoPluginNestedProjectFunctionalTest : FunSpec({
         // when
         project.appendToFile("services/payments/gateway/src/main/kotlin/com/example/Gateway.kt", "\n// Modified")
         project.commitAll("Change gateway")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
         val changed = result.extractChangedProjects()

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/PrintChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/PrintChangedFunctionalTest.kt
@@ -12,9 +12,9 @@ import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.TaskOutcome
 
 /**
- * Functional tests for the printChangedProjects task.
+ * Functional tests for the printChanged task.
  */
-class PrintChangedProjectsFunctionalTest : FunSpec({
+class PrintChangedFunctionalTest : FunSpec({
     val testProjectListener = extension(TestProjectListener())
 
     // --- Detection scenarios (formerly branch-mode) ---
@@ -26,10 +26,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Added comment")
         project.commitAll("Change common-lib")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 5
         changedProjects shouldContainAll setOf(
@@ -51,10 +51,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.MODULE1_SOURCE, "\n// Modified module1")
         project.commitAll("Change module1")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 2
         changedProjects shouldContainAll setOf(Projects.MODULE1, Projects.APP1)
@@ -67,10 +67,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.MODULE2_SOURCE, "\n// Modified module2")
         project.commitAll("Change module2")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 3
         changedProjects shouldContainAll setOf(Projects.MODULE2, Projects.APP1, Projects.APP2)
@@ -83,10 +83,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.APP1_SOURCE, "\n// Modified app")
         project.commitAll("Change app1")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 1
         changedProjects shouldContainAll setOf(Projects.APP1)
@@ -97,10 +97,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         val project = testProjectListener.createStandardProject()
 
         // when
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.extractDirectlyChangedProjects() shouldBe emptySet()
         result.extractChangedProjects() shouldBe emptySet()
     }
@@ -113,10 +113,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         project.appendToFile(Files.APP1_SOURCE, "\n// Modified app1")
         project.appendToFile(Files.APP2_SOURCE, "\n// Modified app2")
         project.commitAll("Change both apps")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 2
         changedProjects shouldContainAll setOf(Projects.APP1, Projects.APP2)
@@ -135,10 +135,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
             class NewFile
             """.trimIndent()
         )
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldContainAll setOf(
             Projects.COMMON_LIB,
@@ -156,10 +156,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.MODULE1_SOURCE, "\n// Staged change")
         project.stageFile(Files.MODULE1_SOURCE)
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldContainAll setOf(Projects.MODULE1, Projects.APP1)
     }
@@ -171,10 +171,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.MODULE2_BUILD, "\n// Build config change")
         project.commitAll("Change build config")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldContainAll setOf(Projects.MODULE2, Projects.APP1, Projects.APP2)
     }
@@ -186,7 +186,7 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         // when
         project.appendToFile(Files.MODULE2_SOURCE, "\n// Changed")
         project.commitAll("Change module2")
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
         val changedProjects = result.extractChangedProjects()
@@ -204,10 +204,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         project.stageFile(Files.COMMON_LIB_SOURCE)
         project.appendToFile(Files.APP2_SOURCE, "\n// Staged app change")
         project.stageFile(Files.APP2_SOURCE)
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changedProjects = result.extractChangedProjects()
         changedProjects shouldHaveSize 5
         changedProjects shouldContainAll setOf(
@@ -221,7 +221,7 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
 
     // --- origin/main baseline scenarios ---
 
-    test("printChangedProjects detects directly changed project using origin/main baseline") {
+    test("printChanged detects directly changed project using origin/main baseline") {
         // given
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -233,15 +233,15 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Modify common-lib")
 
         // when
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContain Projects.COMMON_LIB
     }
 
-    test("printChangedProjects detects transitive dependents using origin/main baseline") {
+    test("printChanged detects transitive dependents using origin/main baseline") {
         // given
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -252,10 +252,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Modify common-lib")
 
         // when
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContainAll setOf(
             Projects.COMMON_LIB,
@@ -266,7 +266,7 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         )
     }
 
-    test("printChangedProjects only shows projects changed since origin/main") {
+    test("printChanged only shows projects changed since origin/main") {
         // given
         val project = StandardTestProject.createAndInitialize(
             testProjectListener.getTestProjectDir(),
@@ -283,17 +283,17 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Modify module1")
 
         // when: compare against origin/main — only module1 changes are newer
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         val changed = result.extractChangedProjects()
         changed shouldContain Projects.MODULE1
         changed shouldContain Projects.APP1
         changed shouldNotContain Projects.COMMON_LIB
     }
 
-    test("printChangedProjects reports which ref was used in output header") {
+    test("printChanged reports which ref was used in output header") {
         // given
         val project = testProjectListener.createStandardProject()
 
@@ -301,10 +301,10 @@ class PrintChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change module1")
 
         // when
-        val result = project.runTask("printChangedProjects")
+        val result = project.runTask("printChanged")
 
         // then
-        result.task(":printChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "Change detection baseline: origin/main ("
         result.output shouldContain "Changed projects (since origin/main @"
     }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateReleaseBranchesFunctionalTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.TaskOutcome
 
-class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
+class CreateReleaseBranchesFunctionalTest : FunSpec({
 
     val testListener = extension(ReleaseTestProjectListener())
 
@@ -23,7 +23,7 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.createBranch("feature/something")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
+        val result = project.runTaskAndFail("createReleaseBranches")
 
         // then
         result.output shouldContain "must run on 'main'"
@@ -34,7 +34,7 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
     // Build dependency chain
     // ─────────────────────────────────────────────────────────────
 
-    test("runs buildChangedProjects and subproject build tasks before creating release branches") {
+    test("runs buildChanged and subproject build tasks before creating release branches") {
         // given
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
         project.createTag("monorepo/last-successful-build")
@@ -44,13 +44,13 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then: the full dependency chain executed
-        result.task(":buildChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
         result.task(":app:build")?.outcome shouldBe TaskOutcome.SUCCESS
         result.task(":lib:build")?.outcome shouldBe TaskOutcome.SUCCESS
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -65,10 +65,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         val headCommit = project.headCommit()
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then: tag still updated (idempotent) even when no changes detected
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "No projects have changed"
         project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
         project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
@@ -88,10 +88,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         val headCommit = project.headCommit()
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
         project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
@@ -110,10 +110,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldContain "release/lib/v0.1.x"
     }
@@ -145,10 +145,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         // If using origin/main: nothing changed (diff C..C) → no release branches
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then: proves the tag is used — app has a release branch
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "Change detection baseline: monorepo/last-successful-build ("
         project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
@@ -183,10 +183,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         // If origin/main is used: nothing changed (diff C..C) → no release branches
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then: proves the tag was fetched from remote and used as baseline
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
     }
 
@@ -203,7 +203,7 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.setRemoteUrl("origin", "/nonexistent/path/to/repo")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
+        val result = project.runTaskAndFail("createReleaseBranches")
 
         // then: build fails with a clear error instead of silently falling back
         result.output shouldContain "Failed to fetch tag"
@@ -225,10 +225,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v0.1.x"
         project.remoteBranches() shouldNotContain "release/lib/v0.1.x"
     }
@@ -253,10 +253,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change both")
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "release/app/v1.0.x"
         project.remoteBranches() shouldContain "release/lib/v1.0.x"
     }
@@ -278,7 +278,7 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.checkoutBranch("main")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
+        val result = project.runTaskAndFail("createReleaseBranches")
 
         // then: task fails; neither branch pushed; tag not updated
         result.output shouldContain "already exists locally"
@@ -318,7 +318,7 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         project.commitAll("Change app")
 
         // when
-        val result = project.runTaskAndFail("createReleaseBranchesForChangedProjects")
+        val result = project.runTaskAndFail("createReleaseBranches")
 
         // then: tag should NOT have moved
         result.output shouldContain "Simulated build failure"
@@ -335,10 +335,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then: no baseline, all projects treated as changed, release branches created
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no baseline exists"
         result.output shouldContain "Change detection baseline: none (all projects treated as changed)"
         project.remoteBranches() shouldContain "release/app/v0.1.x"
@@ -383,10 +383,10 @@ class CreateReleaseBranchesForChangedProjectsFunctionalTest : FunSpec({
         val headCommit = project.headCommit()
 
         // when
-        val result = project.runTask("createReleaseBranchesForChangedProjects")
+        val result = project.runTask("createReleaseBranches")
 
         // then: tag still updated even though no release branches were created
-        result.task(":createReleaseBranchesForChangedProjects")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":createReleaseBranches")?.outcome shouldBe TaskOutcome.SUCCESS
         result.output shouldContain "no release branches to create"
         project.remoteBranches().filter { it.startsWith("release/") } shouldBe emptyList()
         project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/BuildChangedProjectsTaskTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/BuildChangedProjectsTaskTest.kt
@@ -7,7 +7,7 @@ import org.gradle.testfixtures.ProjectBuilder
 
 class BuildChangedProjectsTaskTest : FunSpec({
 
-    test("buildChangedProjects task should be registered") {
+    test("buildChanged task should be registered") {
         // given
         val project = ProjectBuilder.builder().build()
 
@@ -15,13 +15,13 @@ class BuildChangedProjectsTaskTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-release-plugin")
 
         // then
-        val task = project.tasks.findByName("buildChangedProjects")
+        val task = project.tasks.findByName("buildChanged")
         task shouldNotBe null
         task?.group shouldBe "monorepo"
         task?.description shouldBe "Builds only the projects that have been affected by changes"
     }
 
-    test("createReleaseBranchesForChangedProjects task should be registered") {
+    test("createReleaseBranches task should be registered") {
         // given
         val project = ProjectBuilder.builder().build()
 
@@ -29,9 +29,9 @@ class BuildChangedProjectsTaskTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-release-plugin")
 
         // then
-        val task = project.tasks.findByName("createReleaseBranchesForChangedProjects")
+        val task = project.tasks.findByName("createReleaseBranches")
         task shouldNotBe null
-        task?.group shouldBe "monorepo-release"
+        task?.group shouldBe "monorepo"
         task?.description shouldBe "Creates release branches for changed projects"
     }
 })

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildPluginTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildPluginTest.kt
@@ -18,7 +18,7 @@ class MonorepoBuildPluginTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-release-plugin")
 
         // then
-        val task = project.tasks.findByName("printChangedProjects")
+        val task = project.tasks.findByName("printChanged")
         task shouldNotBe null
         task.shouldBeInstanceOf<PrintChangedProjectsTask>()
     }
@@ -76,7 +76,7 @@ class MonorepoBuildPluginTest : FunSpec({
         project.pluginManager.apply("io.github.doug-hawley.monorepo-build-release-plugin")
 
         // when
-        val task = project.tasks.findByName("printChangedProjects")
+        val task = project.tasks.findByName("printChanged")
 
         // then
         task shouldNotBe null


### PR DESCRIPTION
## Summary

- Rename tasks for brevity:
  - `printChangedProjects` → `printChanged`
  - `buildChangedProjects` → `buildChanged`
  - `createReleaseBranchesForChangedProjects` → `createReleaseBranches`
- Unify all tasks under the `monorepo` group (release tasks previously used `monorepo-release`)
- Rename functional test files and classes to match new task names
- Update all documentation (README, CLAUDE.md, CONTRIBUTING, etc.)

**BREAKING CHANGE:** Task names have changed. CI scripts and build files referencing the old names will need updating.

## Test plan

- [x] All 88 tests pass (unit, integration, functional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)