### PR TITLE
fix: fetch remote-tracking branch when missing in CI

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -261,6 +261,15 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
             return null
         }
 
+        if (!gitRepository.refExists(remoteBranch)) {
+            // Many CI environments (e.g. Vela) only fetch the ref being built,
+            // so the remote-tracking branch may not exist locally. Fetch it.
+            try {
+                gitRepository.fetchBranch("origin", primaryBranch)
+            } catch (e: Exception) {
+                project.logger.debug("Could not fetch '$primaryBranch' from origin: ${e.message}")
+            }
+        }
         if (gitRepository.refExists(remoteBranch)) {
             project.logger.debug("Using '$remoteBranch' as base ref")
             return remoteBranch

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/git/GitRepository.kt
@@ -123,6 +123,29 @@ open class GitRepository(
         )
     }
 
+    /**
+     * Fetches a branch from a remote, updating the remote-tracking ref.
+     * Uses `git fetch <remote> <branchName> --quiet` so the local
+     * remote-tracking ref (e.g. origin/main) is created or updated.
+     *
+     * @return true if the fetch succeeded, false if the branch does not exist on the remote
+     * @throws RuntimeException if the fetch fails for an unexpected reason
+     *         (network error, authentication failure, remote misconfigured, etc.)
+     */
+    open fun fetchBranch(remote: String, branchName: String): Boolean {
+        val dir = gitDir ?: return false
+        val result = gitExecutor.executeSilently(dir, "fetch", remote, branchName, "--quiet")
+        if (result.success) {
+            return true
+        }
+        if (result.exitCode == 128 && result.errorOutput.contains(branchName)) {
+            return false
+        }
+        throw RuntimeException(
+            "Failed to fetch branch '$branchName' from '$remote': ${result.errorOutput}"
+        )
+    }
+
     private fun findGitRoot(startDir: File): File? {
         var current: File? = startDir
         while (current != null) {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
@@ -338,4 +338,31 @@ class BuildChangedFunctionalTest : FunSpec({
         val tagCommitAfter = project.getLastCommitSha("monorepo/last-successful-build")
         tagCommitAfter shouldBe tagCommitBefore
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Remote branch fetch (CI scenario)
+    // ─────────────────────────────────────────────────────────────
+
+    test("buildChanged fetches origin/main when not available locally") {
+        // given: project with remote, but remote-tracking ref deleted (simulates CI checkout)
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        project.appendToFile(Files.APP2_SOURCE, "\n// Modified")
+        project.commitAll("Change app2")
+
+        // Delete the remote-tracking ref to simulate a CI checkout that only fetches the build ref
+        project.executeGitCommand("update-ref", "-d", "refs/remotes/origin/main")
+
+        // when
+        val result = project.runTask("buildChanged")
+
+        // then: plugin fetches origin/main and detects the change
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "Change detection baseline: origin/main"
+        val built = result.extractBuiltProjects()
+        built shouldContain Projects.APP2
+    }
 })

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/git/GitRepositoryTest.kt
@@ -334,6 +334,70 @@ class GitRepositoryTest : FunSpec({
         captureOutput(repoDir, "rev-parse", "movable-tag") shouldBe newCommit
         remoteDir.deleteRecursively()
     }
+    // --- fetchBranch ---
+
+    test("fetchBranch returns true and creates remote-tracking ref when branch exists on remote") {
+        // given: set up a bare remote and push main
+        val remoteDir = Files.createTempDirectory("test-git-remote").toFile()
+        git(remoteDir, "init", "--bare")
+        git(repoDir, "remote", "add", "origin", remoteDir.absolutePath)
+        git(repoDir, "push", "-u", "origin", "main")
+
+        // Delete the remote-tracking ref to simulate a CI checkout
+        git(repoDir, "update-ref", "-d", "refs/remotes/origin/main")
+
+        val repo = GitRepository(repoDir, logger)
+        repo.refExists("origin/main") shouldBe false
+
+        // when
+        val result = repo.fetchBranch("origin", "main")
+
+        // then
+        result shouldBe true
+        repo.refExists("origin/main") shouldBe true
+        remoteDir.deleteRecursively()
+    }
+
+    test("fetchBranch returns false when branch does not exist on remote") {
+        // given
+        val remoteDir = Files.createTempDirectory("test-git-remote").toFile()
+        git(remoteDir, "init", "--bare")
+        git(repoDir, "remote", "add", "origin", remoteDir.absolutePath)
+        git(repoDir, "push", "-u", "origin", "main")
+
+        val repo = GitRepository(repoDir, logger)
+
+        // when
+        val result = repo.fetchBranch("origin", "nonexistent-branch")
+
+        // then
+        result shouldBe false
+        remoteDir.deleteRecursively()
+    }
+
+    test("fetchBranch returns false when not inside a git repository") {
+        // given
+        val nonGitDir = Files.createTempDirectory("test-no-git").toFile()
+
+        // when
+        val result = GitRepository(nonGitDir, logger).fetchBranch("origin", "main")
+
+        // then
+        result shouldBe false
+        nonGitDir.deleteRecursively()
+    }
+
+    test("fetchBranch throws when fetch fails for an unexpected reason") {
+        // given: remote points to a non-existent path
+        git(repoDir, "remote", "add", "origin", "/nonexistent/path/to/repo")
+
+        val repo = GitRepository(repoDir, logger)
+
+        // when / then
+        shouldThrow<RuntimeException> {
+            repo.fetchBranch("origin", "main")
+        }
+    }
 })
 
 private fun git(directory: File, vararg command: String) {


### PR DESCRIPTION
## Summary
- CI systems like Vela only fetch the ref being built, so `origin/main` is not available locally for change detection
- The plugin now fetches the primary branch from origin when the remote-tracking ref is missing (non-release runs)
- Fetch is wrapped in a try-catch so environments without a remote (local dev) gracefully fall through to the existing "no baseline" path

## Test plan
- [x] Unit tests for `GitRepository.fetchBranch()` (success, missing branch, no repo, broken remote)
- [x] Functional test simulating CI checkout where `origin/main` is absent
- [x] Existing "no baseline" test still passes (no remote configured)
- [x] Full `check` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)