### PR TITLE
fix: validate git prerequisites before change detection

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -71,6 +71,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
         // computationGuard.compareAndSet(false, true) ensures only the first thread proceeds.
         project.gradle.projectsEvaluated {
             if (rootBuildExtension.computationGuard.compareAndSet(false, true)) {
+                validateGitPrerequisites(project.rootProject)
                 try {
                     val resolvedRef = resolveBaseRef(project.rootProject, rootExtension)
                     rootBuildExtension.resolvedBaseRef = resolvedRef
@@ -435,6 +436,32 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
                 val failure: Throwable? = state.failure
                 state.executed && failure == null
             }
+        }
+    }
+
+    /**
+     * Validates that git is installed and the project is inside a git repository.
+     * Called early in [apply] to produce clear error messages instead of letting
+     * opaque ProcessBuilder failures surface later during change detection.
+     */
+    private fun validateGitPrerequisites(project: Project) {
+        val executor = GitCommandExecutor(project.logger)
+        val versionResult = executor.executeSilently(project.rootDir, "--version")
+        if (!versionResult.success) {
+            throw GradleException(
+                "git is not installed or not on PATH. " +
+                "The monorepo-build-release-plugin requires git to detect changes. " +
+                "Install git and ensure it is available on your system PATH."
+            )
+        }
+
+        val gitRepository = GitRepository(project.rootDir, project.logger)
+        if (!gitRepository.isRepository()) {
+            throw GradleException(
+                "The project root '${project.rootDir}' is not inside a git repository. " +
+                "The monorepo-build-release-plugin requires a git repository to detect changes. " +
+                "Initialize a repository with 'git init'."
+            )
         }
     }
 }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
@@ -74,4 +74,20 @@ class MonorepoPluginConfigurationTest : FunSpec({
         result.output shouldContain "monorepo-build-release-plugin is incompatible with the Gradle configuration cache"
         result.output shouldContain "org.gradle.configuration-cache=false"
     }
+
+    test("plugin fails with helpful error when not inside a git repository") {
+        // given: a project with the plugin applied but no git init
+        val projectDir = testProjectListener.getTestProjectDir()
+        val project = TestProjectBuilder(projectDir)
+            .withSubproject("app")
+            .applyPlugin()
+            .build()
+
+        // when
+        val result = project.runTaskAndFail("printChanged")
+
+        // then
+        result.output shouldContain "not inside a git repository"
+        result.output shouldContain "git init"
+    }
 })


### PR DESCRIPTION
## Summary
- Adds early validation that `git` is installed and the project is inside a git repository
- Runs at the top of the `projectsEvaluated` callback, before any git operations execute
- Produces clear, actionable error messages instead of opaque `ProcessBuilder` / `IOException` failures in CI environments where git may not be present

## Test plan
- [x] Functional test for "not inside a git repository" error message
- [x] Existing unit tests pass (validation runs in `projectsEvaluated`, not `apply()`, so `ProjectBuilder` tests are unaffected)
- [x] Full `check` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)