### PR TITLE
fix: harden git output checks against stderr contamination

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
@@ -16,7 +16,8 @@ class GitReleaseExecutor(
 
     fun isDirty(): Boolean {
         val result = executor.execute(rootDir, "status", "--porcelain")
-        return result.output.isNotEmpty()
+        val porcelainLine = Regex("[MTADRCU?! ]{2} .+")
+        return result.output.any { porcelainLine.matches(it) }
     }
 
     fun currentBranch(): String {
@@ -24,7 +25,7 @@ class GitReleaseExecutor(
         if (!result.success || result.output.isEmpty()) {
             throw GradleException("Failed to determine current git branch: ${result.errorOutput}")
         }
-        return result.output.first().trim()
+        return result.output.last().trim()
     }
 
     fun createTagLocally(tag: String) {
@@ -101,11 +102,11 @@ class GitReleaseExecutor(
 
     fun branchExistsLocally(branch: String): Boolean {
         val result = executor.execute(rootDir, "branch", "--list", branch)
-        return result.success && result.output.isNotEmpty()
+        return result.success && result.output.any { it.trim().removePrefix("* ") == branch }
     }
 
     fun branchExistsOnRemote(branch: String): Boolean {
-        val result = executor.executeSilently(rootDir, "ls-remote", "--heads", "origin", branch)
-        return result.success && result.output.isNotEmpty()
+        val result = executor.executeSilently(rootDir, "ls-remote", "--exit-code", "--heads", "origin", branch)
+        return result.success
     }
 }

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitTagScanner.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitTagScanner.kt
@@ -67,7 +67,7 @@ class GitTagScanner(
      */
     fun tagExists(tag: String): Boolean {
         val output = executor.executeForOutput(rootDir, "tag", "-l", tag)
-        return output.isNotEmpty()
+        return output.any { it.trim() == tag }
     }
 
     private fun parseBranchFromLsRemoteLine(line: String, globalPrefix: String, projectPrefix: String): SemanticVersion? {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseChangedFunctionalTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.gradle.testkit.runner.TaskOutcome
 
 class ReleaseChangedFunctionalTest : FunSpec({
@@ -453,6 +454,53 @@ class ReleaseChangedFunctionalTest : FunSpec({
         result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteTags() shouldContain "release/app/v0.1.0"
         project.releaseVersionFile() shouldBe "0.1.0"
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Stderr contamination during ls-remote (regression)
+    // ─────────────────────────────────────────────────────────────
+
+    test("creates release branch when git produces stderr output during ls-remote") {
+        // given: use file:// protocol to force pack protocol negotiation, plus
+        // GIT_TRACE_PACKET to produce stderr output. This reproduces the CI bug
+        // where credential-helper or TLS messages on stderr were merged into stdout
+        // by redirectErrorStream(true), causing branchExistsOnRemote to return a
+        // false positive (exit code 0 + non-empty output = "branch exists").
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.useFileProtocol()
+        project.createTag("monorepo/last-successful-build")
+        project.pushTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.commitAll("Change app")
+
+        // when: GIT_TRACE_PACKET produces stderr during ls-remote, simulating CI stderr contamination
+        val result = project.runTask("releaseChanged", env = mapOf("GIT_TRACE_PACKET" to "1"))
+
+        // then: branch is created — not incorrectly skipped as "already exists"
+        result.task(":releaseChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+        result.output shouldNotContain "already exists on remote"
+    }
+
+    test("creates release branch when GIT_TRACE contaminates stderr on all git commands") {
+        // given: GIT_TRACE=1 produces trace output on stderr for every git command.
+        // With redirectErrorStream(true), trace lines are merged into stdout.
+        // This verifies currentBranch, branchExistsLocally, and branchExistsOnRemote
+        // all handle trace contamination correctly.
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.createTag("monorepo/last-successful-build")
+        project.pushTag("monorepo/last-successful-build")
+        project.modifyFile("app/app.txt", "changed")
+        project.commitAll("Change app")
+
+        // when
+        val result = project.runTask("releaseChanged", env = mapOf("GIT_TRACE" to "1"))
+
+        // then: all checks pass despite trace contamination
+        result.task(":releaseChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+        result.output shouldNotContain "already exists on remote"
+        result.output shouldNotContain "already exists locally"
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseTaskFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseTaskFunctionalTest.kt
@@ -516,6 +516,28 @@ class ReleaseTaskFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
+    // Stderr contamination (regression)
+    // ─────────────────────────────────────────────────────────────
+
+    test("release succeeds when GIT_TRACE contaminates stderr on all git commands") {
+        // given: GIT_TRACE=1 produces trace output on stderr for every git command.
+        // With redirectErrorStream(true), trace lines are merged into stdout.
+        // This verifies isDirty, currentBranch, and tagExists all handle trace
+        // contamination without false positives.
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("release/app/v0.1.x")
+        project.executeGitPush("release/app/v0.1.x")
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTask(":app:release", env = mapOf("GIT_TRACE" to "1"))
+
+        // then: all guardrails pass despite trace contamination
+        result.task(":app:release")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteTags() shouldContain "release/app/v0.1.0"
+    }
+
+    // ─────────────────────────────────────────────────────────────
     // Push and rollback
     // ─────────────────────────────────────────────────────────────
 

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/StandardReleaseTestProject.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/StandardReleaseTestProject.kt
@@ -385,23 +385,28 @@ class ReleaseTestProject(
         file.writeText(content)
     }
 
-    fun runTask(vararg tasks: String, properties: Map<String, String> = emptyMap()): BuildResult {
+    fun useFileProtocol() {
+        setRemoteUrl("origin", "file://${remoteDir.absolutePath}")
+    }
+
+    fun runTask(vararg tasks: String, properties: Map<String, String> = emptyMap(), env: Map<String, String> = emptyMap()): BuildResult {
         val args = tasks.toMutableList()
         properties.forEach { (k, v) -> args.add("-P$k=$v") }
         args.addAll(listOf("--stacktrace"))
-        return gradleRunner().withArguments(args).build()
+        return gradleRunner(env).withArguments(args).build()
     }
 
-    fun runTaskAndFail(vararg tasks: String, properties: Map<String, String> = emptyMap()): BuildResult {
+    fun runTaskAndFail(vararg tasks: String, properties: Map<String, String> = emptyMap(), env: Map<String, String> = emptyMap()): BuildResult {
         val args = tasks.toMutableList()
         properties.forEach { (k, v) -> args.add("-P$k=$v") }
         args.addAll(listOf("--stacktrace"))
-        return gradleRunner().withArguments(args).buildAndFail()
+        return gradleRunner(env).withArguments(args).buildAndFail()
     }
 
-    private fun gradleRunner(): GradleRunner {
+    private fun gradleRunner(extraEnv: Map<String, String> = emptyMap()): GradleRunner {
         val env = HashMap(System.getenv())
         env.keys.removeIf { it.startsWith("DEVELOCITY_") || it.startsWith("GRADLE_BUILD_ACTION_") }
+        env.putAll(extraEnv)
         return GradleRunner.create()
             .withProjectDir(projectDir)
             .withEnvironment(env)

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutorTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutorTest.kt
@@ -43,6 +43,15 @@ class GitReleaseExecutorTest : FunSpec({
         releaseExecutor.isDirty() shouldBe true
     }
 
+    test("isDirty returns false when output contains only non-porcelain lines like stderr trace output") {
+        // given: trace output from GIT_TRACE=1 merged via redirectErrorStream(true)
+        every { executor.execute(rootDir, "status", "--porcelain") } returns
+            CommandResult(success = true, output = listOf("trace: built-in: git status --porcelain"), exitCode = 0)
+
+        // when / then
+        releaseExecutor.isDirty() shouldBe false
+    }
+
     // currentBranch
 
     test("currentBranch returns the branch name from git output") {
@@ -80,6 +89,19 @@ class GitReleaseExecutorTest : FunSpec({
 
         // when / then
         shouldThrow<GradleException> { releaseExecutor.currentBranch() }
+    }
+
+    test("currentBranch returns correct branch when trace output precedes actual output") {
+        // given: trace output from GIT_TRACE=1 appears before the branch name
+        every { executor.execute(rootDir, "rev-parse", "--abbrev-ref", "HEAD") } returns
+            CommandResult(
+                success = true,
+                output = listOf("trace: built-in: git rev-parse --abbrev-ref HEAD", "main"),
+                exitCode = 0
+            )
+
+        // when / then
+        releaseExecutor.currentBranch() shouldBe "main"
     }
 
     // createTagLocally
@@ -242,21 +264,68 @@ class GitReleaseExecutorTest : FunSpec({
         ex.message shouldContain "Atomic push of 2 ref(s) failed"
     }
 
+    // branchExistsLocally
+
+    test("branchExistsLocally returns true when output contains the branch name") {
+        // given
+        every { executor.execute(rootDir, "branch", "--list", "release/app/v0.1.x") } returns
+            CommandResult(success = true, output = listOf("  release/app/v0.1.x"), exitCode = 0)
+
+        // when / then
+        releaseExecutor.branchExistsLocally("release/app/v0.1.x") shouldBe true
+    }
+
+    test("branchExistsLocally returns true when branch is the current branch") {
+        // given: git branch --list shows current branch with asterisk prefix
+        every { executor.execute(rootDir, "branch", "--list", "release/app/v0.1.x") } returns
+            CommandResult(success = true, output = listOf("* release/app/v0.1.x"), exitCode = 0)
+
+        // when / then
+        releaseExecutor.branchExistsLocally("release/app/v0.1.x") shouldBe true
+    }
+
+    test("branchExistsLocally returns false when output is empty") {
+        // given
+        every { executor.execute(rootDir, "branch", "--list", "release/app/v0.1.x") } returns
+            CommandResult(success = true, output = emptyList(), exitCode = 0)
+
+        // when / then
+        releaseExecutor.branchExistsLocally("release/app/v0.1.x") shouldBe false
+    }
+
+    test("branchExistsLocally returns false when output contains only non-branch lines like stderr trace output") {
+        // given: trace output from GIT_TRACE=1 merged via redirectErrorStream(true)
+        every { executor.execute(rootDir, "branch", "--list", "release/app/v0.1.x") } returns
+            CommandResult(success = true, output = listOf("trace: built-in: git branch --list release/app/v0.1.x"), exitCode = 0)
+
+        // when / then
+        releaseExecutor.branchExistsLocally("release/app/v0.1.x") shouldBe false
+    }
+
+    test("branchExistsLocally returns false when command fails") {
+        // given
+        every { executor.execute(rootDir, "branch", "--list", "release/app/v0.1.x") } returns
+            CommandResult(success = false, output = emptyList(), exitCode = 128, errorOutput = "fatal error")
+
+        // when / then
+        releaseExecutor.branchExistsLocally("release/app/v0.1.x") shouldBe false
+    }
+
     // branchExistsOnRemote
 
-    test("branchExistsOnRemote returns true when ls-remote returns output") {
+    test("branchExistsOnRemote returns true when ls-remote exits with code 0") {
         // given
-        every { executor.executeSilently(rootDir, "ls-remote", "--heads", "origin", "release/app/v0.1.x") } returns
+        every { executor.executeSilently(rootDir, "ls-remote", "--exit-code", "--heads", "origin", "release/app/v0.1.x") } returns
             CommandResult(success = true, output = listOf("abc123\trefs/heads/release/app/v0.1.x"), exitCode = 0)
 
         // when / then
         releaseExecutor.branchExistsOnRemote("release/app/v0.1.x") shouldBe true
     }
 
-    test("branchExistsOnRemote returns false when ls-remote returns empty output") {
+    test("branchExistsOnRemote returns false when ls-remote exits with code 2") {
         // given
-        every { executor.executeSilently(rootDir, "ls-remote", "--heads", "origin", "release/app/v0.1.x") } returns
-            CommandResult(success = true, output = emptyList(), exitCode = 0)
+        every { executor.executeSilently(rootDir, "ls-remote", "--exit-code", "--heads", "origin", "release/app/v0.1.x") } returns
+            CommandResult(success = false, output = emptyList(), exitCode = 2, errorOutput = "")
 
         // when / then
         releaseExecutor.branchExistsOnRemote("release/app/v0.1.x") shouldBe false
@@ -264,7 +333,7 @@ class GitReleaseExecutorTest : FunSpec({
 
     test("branchExistsOnRemote returns false when command fails") {
         // given
-        every { executor.executeSilently(rootDir, "ls-remote", "--heads", "origin", "release/app/v0.1.x") } returns
+        every { executor.executeSilently(rootDir, "ls-remote", "--exit-code", "--heads", "origin", "release/app/v0.1.x") } returns
             CommandResult(success = false, output = emptyList(), exitCode = 128, errorOutput = "remote error")
 
         // when / then

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/git/GitTagScannerTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/git/GitTagScannerTest.kt
@@ -219,4 +219,17 @@ class GitTagScannerTest : FunSpec({
         // then
         result shouldBe false
     }
+
+    test("tagExists returns false when output contains only non-tag lines like stderr trace output") {
+        // given: trace output from GIT_TRACE=1 merged via redirectErrorStream(true)
+        every {
+            executor.executeForOutput(rootDir, "tag", "-l", "release/app/v1.0.0")
+        } returns listOf("trace: built-in: git tag -l release/app/v1.0.0")
+
+        // when
+        val result = scanner.tagExists("release/app/v1.0.0")
+
+        // then
+        result shouldBe false
+    }
 })


### PR DESCRIPTION
## Summary
- `GitCommandExecutor` uses `redirectErrorStream(true)`, merging stderr into stdout. Several methods checked `output.isNotEmpty()` without validating format, causing false positives when git produces stderr messages (credential helpers, `GIT_TRACE`, TLS warnings) in CI environments.
- Fixes `branchExistsOnRemote` (add `--exit-code`), `isDirty` (porcelain format filter), `currentBranch` (`last()` instead of `first()`), `branchExistsLocally` (validate branch name), and `tagExists` (validate tag name).
- Adds unit tests for each stderr contamination scenario and functional regression tests using `GIT_TRACE=1` and `GIT_TRACE_PACKET=1` to reproduce the issue end-to-end.

## Test plan
- [x] Unit tests verify each method ignores trace/warning lines in output
- [x] Functional test: `releaseChanged` succeeds with `GIT_TRACE=1` (covers `currentBranch`, `branchExistsLocally`, `branchExistsOnRemote`)
- [x] Functional test: `releaseChanged` succeeds with `GIT_TRACE_PACKET=1` + `file://` protocol (reproduces original CI bug)
- [x] Functional test: `release` task succeeds with `GIT_TRACE=1` (covers `isDirty`, `currentBranch`, `tagExists`)
- [x] All three functional tests verified to **fail without the fixes** and **pass with the fixes**
- [x] Full `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)