### PR TITLE
feat: configurable target branch for PR builds via -Pmonorepo.targetBranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ The plugin detects changes by comparing HEAD against a baseline ref. The baselin
 - **CI release builds** (`releaseChanged`): uses the `lastSuccessfulBuildTag`. If the tag doesn't exist (e.g., first run), all projects are treated as changed.
 - **Dev and PR builds** (all other tasks): uses `origin/{primaryBranch}`. If the remote branch isn't available, all projects are treated as changed.
 
+For PRs targeting a branch other than `primaryBranch` (e.g., a release branch), pass the target branch via `-Pmonorepo.targetBranch`:
+
+```bash
+./gradlew buildChanged -Pmonorepo.targetBranch=release/app/v0.1.x
+```
+
+The plugin will use `origin/{targetBranch}` as the baseline instead of `origin/{primaryBranch}`, fetching the branch from origin if needed. This only affects build tasks (`buildChanged`, `printChanged`, per-project `buildChanged`); `releaseChanged` continues to use the last-successful-build tag.
+
 Individual subprojects can declare their own exclude patterns using the `monorepoProject` extension. Patterns are matched against paths relative to the subproject directory and are applied after global `excludePatterns`.
 
 ```kotlin
@@ -399,6 +407,14 @@ Applied per subproject to opt in to release management.
 |----------|------|---------|-------------|
 | `enabled` | Boolean | `false` | Whether this subproject participates in releases |
 | `tagPrefix` | String? | `null` | Override the auto-derived tag prefix (default derives from Gradle path: `:api:core` → `api-core`) |
+
+### Gradle Properties
+
+Command-line properties passed via `-P`:
+
+| Property | Applies To | Description |
+|----------|-----------|-------------|
+| `monorepo.targetBranch` | `buildChanged`, `printChanged`, per-project `buildChanged` | Overrides the default `origin/{primaryBranch}` baseline with `origin/{value}`. Accepts both `release/v1.x` and `origin/release/v1.x`. The branch is fetched from origin if not available locally. If the ref doesn't exist, all projects are treated as changed. Has no effect on `releaseChanged`. |
 
 ## Troubleshooting
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -273,6 +273,32 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
             return null
         }
 
+        val targetBranch = project.findProperty("monorepo.targetBranch") as? String
+        if (targetBranch != null) {
+            val remoteRef = if (targetBranch.startsWith("origin/")) targetBranch else "origin/$targetBranch"
+            if (!gitRepository.refExists(remoteRef)) {
+                val branchName = if (targetBranch.startsWith("origin/")) {
+                    targetBranch.removePrefix("origin/")
+                } else {
+                    targetBranch
+                }
+                try {
+                    gitRepository.fetchBranch("origin", branchName)
+                } catch (e: Exception) {
+                    project.logger.debug("Could not fetch '$branchName' from origin: ${e.message}")
+                }
+            }
+            if (gitRepository.refExists(remoteRef)) {
+                project.logger.debug("Using target branch '$remoteRef' as base ref (from -Pmonorepo.targetBranch)")
+                return remoteRef
+            }
+            project.logger.lifecycle(
+                "'$remoteRef' (from -Pmonorepo.targetBranch) is not available — no baseline exists. " +
+                "All projects will be treated as changed."
+            )
+            return null
+        }
+
         if (!gitRepository.refExists(remoteBranch)) {
             // Many CI environments (e.g. Vela) only fetch the ref being built,
             // so the remote-tracking branch may not exist locally. Fetch it.

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
@@ -365,4 +365,159 @@ class BuildChangedFunctionalTest : FunSpec({
         val built = result.extractBuiltProjects()
         built shouldContain Projects.APP2
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // monorepo.targetBranch property scenarios
+    // ─────────────────────────────────────────────────────────────
+
+    test("buildChanged uses monorepo.targetBranch as baseline when set") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        // Create a release branch at the current commit
+        project.executeGitCommand("branch", "release/v1.0.x")
+        project.executeGitCommand("push", "origin", "release/v1.0.x")
+
+        // Make changes on main after the branch point
+        project.appendToFile(Files.COMMON_LIB_SOURCE, "\n// Change on main")
+        project.commitAll("Change common-lib on main")
+
+        project.appendToFile(Files.MODULE1_SOURCE, "\n// Feature change")
+        project.commitAll("Change module1")
+
+        // when: compare against the release branch, not origin/main
+        val result = project.runTaskWithProperties(
+            "buildChanged",
+            properties = mapOf("monorepo.targetBranch" to "release/v1.0.x")
+        )
+
+        // then: both changes since the branch point are detected
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "Change detection baseline: origin/release/v1.0.x"
+        val built = result.extractBuiltProjects()
+        built shouldContainAll setOf(
+            Projects.COMMON_LIB,
+            Projects.MODULE1,
+            Projects.MODULE2,
+            Projects.APP1,
+            Projects.APP2
+        )
+    }
+
+    test("buildChanged with monorepo.targetBranch overrides origin/main") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        project.appendToFile(Files.APP2_SOURCE, "\n// Modified")
+        project.commitAll("Change app2")
+
+        // when: explicitly pass main — same as default but exercises the property path
+        val result = project.runTaskWithProperties(
+            "buildChanged",
+            properties = mapOf("monorepo.targetBranch" to "main")
+        )
+
+        // then: same behaviour as without the property
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "Change detection baseline: origin/main"
+        val built = result.extractBuiltProjects()
+        built shouldContain Projects.APP2
+        built shouldNotContain Projects.COMMON_LIB
+    }
+
+    test("buildChanged fetches target branch when not available locally") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        // Create and push a release branch
+        project.executeGitCommand("branch", "release/v1.0.x")
+        project.executeGitCommand("push", "origin", "release/v1.0.x")
+
+        // Delete the local remote-tracking ref to simulate CI
+        project.executeGitCommand("update-ref", "-d", "refs/remotes/origin/release/v1.0.x")
+
+        project.appendToFile(Files.MODULE2_SOURCE, "\n// Feature change")
+        project.commitAll("Change module2")
+
+        // when
+        val result = project.runTaskWithProperties(
+            "buildChanged",
+            properties = mapOf("monorepo.targetBranch" to "release/v1.0.x")
+        )
+
+        // then: plugin fetches the branch and resolves successfully
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "Change detection baseline: origin/release/v1.0.x"
+        val built = result.extractBuiltProjects()
+        built shouldContain Projects.MODULE2
+        built shouldContain Projects.APP2
+    }
+
+    test("buildChanged treats all as changed when target branch does not exist") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        // when
+        val result = project.runTaskWithProperties(
+            "buildChanged",
+            properties = mapOf("monorepo.targetBranch" to "nonexistent-branch")
+        )
+
+        // then
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "from -Pmonorepo.targetBranch"
+        result.output shouldContain "not available"
+        result.output shouldContain "Change detection baseline: none"
+        val built = result.extractBuiltProjects()
+        built shouldContainAll setOf(
+            Projects.COMMON_LIB,
+            Projects.MODULE1,
+            Projects.MODULE2,
+            Projects.APP1,
+            Projects.APP2
+        )
+    }
+
+    test("buildChanged with monorepo.targetBranch detects changes relative to release branch") {
+        // given
+        val project = StandardTestProject.createAndInitialize(
+            testProjectListener.getTestProjectDir(),
+            withRemote = true
+        )
+
+        // Push initial state, then create release branch
+        project.executeGitCommand("branch", "release/v1.0.x")
+        project.executeGitCommand("push", "origin", "release/v1.0.x")
+
+        // Switch to a feature branch and change only module1
+        project.executeGitCommand("checkout", "-b", "feature/add-widget")
+        project.appendToFile(Files.MODULE1_SOURCE, "\n// Widget feature")
+        project.commitAll("Add widget to module1")
+
+        // when: compare against the release branch
+        val result = project.runTaskWithProperties(
+            "buildChanged",
+            properties = mapOf("monorepo.targetBranch" to "release/v1.0.x")
+        )
+
+        // then: only module1 and its dependents are affected
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        val built = result.extractBuiltProjects()
+        built shouldContainAll setOf(Projects.MODULE1, Projects.APP1)
+        built shouldNotContain Projects.COMMON_LIB
+        built shouldNotContain Projects.MODULE2
+        built shouldNotContain Projects.APP2
+    }
 })


### PR DESCRIPTION
## Summary
- Add `-Pmonorepo.targetBranch` Gradle property to override the default `origin/{primaryBranch}` baseline for change detection in build tasks (`buildChanged`, `printChanged`, per-project `buildChanged`)
- The property accepts both bare branch names (`release/v1.0.x`) and remote-prefixed refs (`origin/release/v1.0.x`), fetching from origin if not available locally
- `releaseChanged` is unaffected — it continues to use the last-successful-build tag

## Test plan
- [x] 5 new functional tests covering: target branch as baseline, explicit main override, fetch when ref missing, nonexistent branch fallback, release branch diff
- [x] Full `./gradlew check` passes (unit, integration, functional tests + plugin validation)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)