### PR TITLE
docs: fix stale releaseChanged descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,25 +188,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **deps:** Bump actions/upload-artifact from 4 to 7 ([c6bf3a2](https://github.com/doug-hawley/monorepo-build-release-plugin/commit/c6bf3a211a94a3ab47ec01ca0920cc5dd79420cf))
 
-## [Unreleased]
-
-### Breaking Changes
-
-* **Unified change detection model** — replaced dual branch-mode/ref-mode with a single tag-based model anchored on `monorepo/last-successful-build`. The following DSL properties and tasks have been removed:
-  * Removed `baseBranch` and `commitRef` from `monorepo { build { } }` — replaced by `lastSuccessfulBuildTag` and `primaryBranch`
-  * Removed `releaseBranchPatterns` from `monorepo { release { } }` — the new aggregator task uses a `primaryBranch` guard instead
-  * Removed `-Pmonorepo.commitRef` runtime override
-  * Removed tasks: `printChangedProjectsFromBranch`, `printChangedProjectsFromRef`, `buildChangedProjectsFromBranch`, `buildChangedProjectsFromRef`, `writeChangedProjectsFromRef`, `createReleaseBranch` (per-subproject), `createReleaseBranchesForChangedProjects`
-
-### Features
-
-* add `primaryBranch` property on root `monorepo { }` extension (default: `"main"`)
-* add `lastSuccessfulBuildTag` property for tag-based change detection (default: `"monorepo/last-successful-build"`)
-* add unified `printChangedProjects` and `buildChangedProjects` tasks replacing 6 old tasks
-* add `buildChangedProjectsAndCreateReleaseBranches` aggregator task with branch guard, atomic release branch creation, and automatic tag update
-* add `AtomicReleaseBranchCreator` for two-phase branch creation with rollback on failure
-* add `LastSuccessfulBuildTagUpdater` for automatic tag advancement after successful builds
-
 ## [0.3.3](https://github.com/doug-hawley/monorepo-build-release-plugin/compare/v0.3.2...v0.3.3) (2026-03-04)
 
 
@@ -283,8 +264,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Build System
 
 * prepare release-please for multi-plugin monorepo ([95ae196](https://github.com/doug-hawley/monorepo-gradle-plugins/commit/95ae196b59d8176ac772175ce7a0f1142f945a6b))
-
-## [Unreleased]
 
 ## [0.2.0] - 2026-02-25
 

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ monorepo {
 
 #### `releaseChanged`
 
-The CI post-merge task. Depends on `buildChanged` to build all affected projects first, then creates version tags and release branches atomically for changed opted-in projects, writes `release-version.txt` per subproject, and updates the last-successful-build tag. Fails fast if the current branch is not `primaryBranch`.
+The CI post-merge task. Depends on `buildChanged` to build all affected projects first, then creates release branches atomically for changed opted-in projects and updates the last-successful-build tag. Fails fast if the current branch is not `primaryBranch`.
 
 ```bash
 ./gradlew releaseChanged
 ```
 
-Tags and release branches are created using a two-phase atomic approach: all refs are created locally first, then pushed together via `git push --atomic`. If any step fails, all local refs are rolled back and the tag is not updated. Release branches are created alongside tags for future patch releases.
+Release branches are created using a two-phase atomic approach: all branches are created locally first, then pushed together via `git push --atomic`. If any step fails, all local branches are rolled back and the tag is not updated. Tagging is delegated to the `:subproject:release` task running on each release branch.
 
 #### `:subproject:release`
 
@@ -240,14 +240,14 @@ The PR is merged into `main` and CI triggers on the merge commit. The plugin com
 ./gradlew releaseChanged
 ```
 
-`:shared-module` changed, so both apps are included via transitive impact. `:shared-module` itself is skipped because it isn't opted in to releases. The task builds all affected projects, creates version tags and release branches atomically, writes `release-version.txt`, and updates the last-successful-build tag — all in one step.
+`:shared-module` changed, so both apps are included via transitive impact. `:shared-module` itself is skipped because it isn't opted in to releases. The task builds all affected projects, creates release branches atomically, and updates the last-successful-build tag — all in one step.
 
-| Project | Tag created | Release branch created |
-|---------|-------------|------------------------|
-| `:app1` | `release/app1/v0.1.0` | `release/app1/v0.1.x`  |
-| `:app2` | `release/app2/v0.1.0` | `release/app2/v0.1.x`  |
+| Project | Release branch created |
+|---------|------------------------|
+| `:app1` | `release/app1/v0.1.x`  |
+| `:app2` | `release/app2/v0.1.x`  |
 
-The `releaseChanged` task writes the released version to `build/release-version.txt` per subproject, which your CI/CD pipeline can read for publishing:
+Tagging is delegated to the `:subproject:release` task. When that task runs on a release branch, it creates the version tag and writes `build/release-version.txt`, which your CI/CD pipeline can read for publishing:
 
 ```bash
 VERSION=$(cat app1/build/release-version.txt)
@@ -305,7 +305,7 @@ ruleset:
   tag: "release/*/v*"    # only version tags, not monorepo/last-successful-build
 ```
 
-Since `releaseChanged` writes `release-version.txt` per subproject, your publish step can read the version directly:
+Since the `release` task writes `release-version.txt` per subproject, your publish step can read the version directly:
 
 ```yaml
 steps:
@@ -339,7 +339,7 @@ jobs:
       - run: ./gradlew releaseChanged
 ```
 
-> **Note:** `releaseChanged` creates version tags, release branches, and writes `release-version.txt` — all in one step. No separate release branch pipeline is needed for the initial release. Release branches exist for future patch releases only.
+> **Note:** `releaseChanged` creates release branches and updates the last-successful-build tag. Tagging and `release-version.txt` are handled by the `:subproject:release` task on each release branch. A separate release branch workflow (below) is needed to create version tags.
 
 #### Workflow for patch releases from release branches
 


### PR DESCRIPTION
## Summary
- `releaseChanged` only creates release branches — tagging and `release-version.txt` are handled by `:sub:release` on the release branch. Updated README task descriptions, example table, and CI/CD guides to reflect the current two-step flow.
- Removed two stale `[Unreleased]` sections from CHANGELOG that referenced old task/class names (`printChangedProjects`, `AtomicReleaseBranchCreator`, etc.) already captured in versioned entries.

## Test plan
- [x] Documentation-only changes — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)