### PR TITLE
feat: add minimumVersion config for adopting plugin on existing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ monorepoProject {
 }
 ```
 
+When adopting the plugin on a project that already has released versions from a different release mechanism, set `minimumVersion` so the plugin starts versioning past existing releases:
+
+```kotlin
+monorepoProject {
+    release {
+        enabled = true
+        minimumVersion = "2.4.0"  // existing releases go up to 2.4.0
+    }
+}
+```
+
+With `primaryBranchScope = "minor"`, the first release branch will be `release/{project}/v2.5.x`. Once the project has released past the minimum, the config can be removed.
+
 ### Global configuration
 
 ```kotlin
@@ -407,6 +420,7 @@ Applied per subproject to opt in to release management.
 |----------|------|---------|-------------|
 | `enabled` | Boolean | `false` | Whether this subproject participates in releases |
 | `tagPrefix` | String? | `null` | Override the auto-derived tag prefix (default derives from Gradle path: `:api:core` → `api-core`) |
+| `minimumVersion` | String? | `null` | Version floor for adoption scenarios (e.g., `"2.4.0"`). When set, the plugin treats this as the baseline if no higher plugin-managed tags exist. Must be a valid semver string. |
 
 ### Gradle Properties
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -11,6 +11,7 @@ import io.github.doughawley.monorepo.build.task.PrintChangedProjectsTask
 import io.github.doughawley.monorepo.release.MonorepoReleaseConfigExtension
 import io.github.doughawley.monorepo.release.MonorepoReleaseExtension
 import io.github.doughawley.monorepo.release.domain.Scope
+import io.github.doughawley.monorepo.release.domain.SemanticVersion
 import io.github.doughawley.monorepo.release.domain.TagPattern
 import io.github.doughawley.monorepo.release.git.ReleaseBranchCreator
 import io.github.doughawley.monorepo.release.task.ReleaseTask
@@ -181,15 +182,27 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
 
                 // Collect opted-in changed projects
                 val changedProjects = buildExt.allAffectedProjects
-                val optedInProjects = changedProjects.mapNotNull { projectPath ->
-                    val targetProject = rootProject.findProject(projectPath) ?: return@mapNotNull null
+                val optedInProjects = mutableMapOf<String, String>()
+                val minimumVersions = mutableMapOf<String, SemanticVersion>()
+                for (projectPath in changedProjects) {
+                    val targetProject = rootProject.findProject(projectPath) ?: continue
                     val projectExt = targetProject.extensions.findByType(MonorepoProjectExtension::class.java)
-                        ?: return@mapNotNull null
-                    if (!projectExt.release.enabled) return@mapNotNull null
+                        ?: continue
+                    if (!projectExt.release.enabled) continue
                     val tagPrefix = projectExt.release.tagPrefix
                         ?: TagPattern.deriveProjectTagPrefix(projectPath)
-                    projectPath to tagPrefix
-                }.toMap()
+                    optedInProjects[projectPath] = tagPrefix
+
+                    val minVersionStr = projectExt.release.minimumVersion
+                    if (minVersionStr != null) {
+                        val parsed = SemanticVersion.parse(minVersionStr)
+                            ?: throw GradleException(
+                                "Invalid minimumVersion '$minVersionStr' for project $projectPath. " +
+                                "Must be a valid semver string (e.g., '1.2.3')."
+                            )
+                        minimumVersions[projectPath] = parsed
+                    }
+                }
 
                 val tagUpdater = LastSuccessfulBuildTagUpdater(rootDir, executor, logger)
 
@@ -220,7 +233,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
                 // Create release branches
                 val tagScanner = GitTagScanner(rootDir, executor)
                 val releaseCreator = ReleaseBranchCreator(releaseExecutor, tagScanner, logger)
-                releaseCreator.releaseProjects(optedInProjects, releaseExt.globalTagPrefix, scope)
+                releaseCreator.releaseProjects(optedInProjects, releaseExt.globalTagPrefix, scope, minimumVersions)
 
                 // Update last-successful-build tag
                 tagUpdater.updateTag(buildExt.lastSuccessfulBuildTag)

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/MonorepoReleaseConfigExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/MonorepoReleaseConfigExtension.kt
@@ -3,4 +3,5 @@ package io.github.doughawley.monorepo.release
 open class MonorepoReleaseConfigExtension {
     var enabled: Boolean = false
     var tagPrefix: String? = null
+    var minimumVersion: String? = null
 }

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolver.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolver.kt
@@ -20,11 +20,24 @@ object NextVersionResolver {
      * @param latestVersion the highest existing version across all version lines, or null if no tags exist
      * @param scope the bump scope (major or minor)
      */
-    fun forMainBranch(latestVersion: SemanticVersion?, scope: Scope): SemanticVersion {
-        return if (latestVersion == null) {
+    fun forMainBranch(
+        latestVersion: SemanticVersion?,
+        scope: Scope,
+        minimumVersion: SemanticVersion? = null
+    ): SemanticVersion {
+        val effectiveLatest = maxOfNullable(latestVersion, minimumVersion)
+        return if (effectiveLatest == null) {
             SemanticVersion(0, 1, 0)
         } else {
-            latestVersion.bump(scope)
+            effectiveLatest.bump(scope)
+        }
+    }
+
+    private fun <T : Comparable<T>> maxOfNullable(a: T?, b: T?): T? {
+        return when {
+            a == null -> b
+            b == null -> a
+            else -> maxOf(a, b)
         }
     }
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/ReleaseBranchCreator.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/ReleaseBranchCreator.kt
@@ -41,14 +41,15 @@ class ReleaseBranchCreator(
     fun releaseProjects(
         projects: Map<String, String>,
         globalPrefix: String,
-        scope: Scope
+        scope: Scope,
+        minimumVersions: Map<String, SemanticVersion> = emptyMap()
     ): ReleaseResult {
         if (projects.isEmpty()) {
             logger.lifecycle("No opted-in changed projects — nothing to release")
             return ReleaseResult(emptyList(), emptyMap(), emptyMap())
         }
 
-        val allResolved = resolveReleases(projects, globalPrefix, scope)
+        val allResolved = resolveReleases(projects, globalPrefix, scope, minimumVersions)
 
         val branches = allResolved.values.map { it.branch }
 
@@ -99,13 +100,15 @@ class ReleaseBranchCreator(
     private fun resolveReleases(
         projects: Map<String, String>,
         globalPrefix: String,
-        scope: Scope
+        scope: Scope,
+        minimumVersions: Map<String, SemanticVersion>
     ): Map<String, ResolvedRelease> {
-        return projects.mapValues { (_, projectPrefix) ->
+        return projects.mapValues { (projectPath, projectPrefix) ->
             val latestTagVersion = gitTagScanner.findLatestVersion(globalPrefix, projectPrefix)
             val latestBranchVersion = gitTagScanner.findLatestBranchVersion(globalPrefix, projectPrefix)
             val latestVersion = maxOfNullable(latestTagVersion, latestBranchVersion)
-            val nextVersion = NextVersionResolver.forMainBranch(latestVersion, scope)
+            val minimumVersion = minimumVersions[projectPath]
+            val nextVersion = NextVersionResolver.forMainBranch(latestVersion, scope, minimumVersion)
             ResolvedRelease(
                 version = nextVersion,
                 branch = TagPattern.formatReleaseBranch(globalPrefix, projectPrefix, nextVersion)

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseChangedFunctionalTest.kt
@@ -481,6 +481,81 @@ class ReleaseChangedFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
+    // minimumVersion — adoption scenario
+    // ─────────────────────────────────────────────────────────────
+
+    test("creates release branch starting from minimumVersion when no prior tags exist") {
+        // given: adopting plugin on a project whose latest external release is 1.2.3
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        val appBuild = java.io.File(project.projectDir, "app/build.gradle.kts")
+        appBuild.writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = true
+                    minimumVersion = "1.2.3"
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.commitAll("Set minimumVersion")
+        project.createTag("monorepo/last-successful-build")
+        project.pushTag("monorepo/last-successful-build")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "changed")
+        project.commitAll("Change app")
+
+        // when
+        val result = project.runTask("releaseChanged")
+
+        // then — bumps minor from 1.2.3 → branch v1.3.x
+        result.task(":releaseChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v1.3.x"
+    }
+
+    test("fails with clear error when minimumVersion is invalid") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        val appBuild = java.io.File(project.projectDir, "app/build.gradle.kts")
+        appBuild.writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = true
+                    minimumVersion = "not-a-version"
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.commitAll("Set invalid minimumVersion")
+        project.createTag("monorepo/last-successful-build")
+        project.pushTag("monorepo/last-successful-build")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "changed")
+        project.commitAll("Change app")
+
+        // when
+        val result = project.runTaskAndFail("releaseChanged")
+
+        // then
+        result.output shouldContain "Invalid minimumVersion 'not-a-version'"
+    }
+
+    // ─────────────────────────────────────────────────────────────
     // All disabled
     // ─────────────────────────────────────────────────────────────
 

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/ReleaseBranchCreatorIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/ReleaseBranchCreatorIntegrationTest.kt
@@ -2,6 +2,7 @@ package io.github.doughawley.monorepo.release.git
 
 import io.github.doughawley.monorepo.git.GitCommandExecutor
 import io.github.doughawley.monorepo.release.domain.Scope
+import io.github.doughawley.monorepo.release.domain.SemanticVersion
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -129,6 +130,21 @@ class ReleaseBranchCreatorIntegrationTest : FunSpec({
         // then: major bump → v1.0.x branch
         result.createdBranches shouldContainExactlyInAnyOrder listOf("release/app/v1.0.x")
         repoListener.repo.remoteBranchExists("release/app/v1.0.x") shouldBe true
+    }
+
+    test("uses minimumVersion as baseline when no tags exist") {
+        // given — adopting plugin on a project whose latest external release is 1.2.3
+        val creator = createCreator()
+        val projects = mapOf(":app" to "app")
+        val minimumVersions = mapOf(":app" to SemanticVersion(1, 2, 3))
+
+        // when
+        val result = creator.releaseProjects(projects, "release", Scope.MINOR, minimumVersions)
+
+        // then — bumps minor from 1.2.3 → 1.3.0, branch is v1.3.x
+        result.createdBranches shouldContainExactlyInAnyOrder listOf("release/app/v1.3.x")
+        result.projectToVersion[":app"]?.toString() shouldBe "1.3.0"
+        repoListener.repo.remoteBranchExists("release/app/v1.3.x") shouldBe true
     }
 
     test("rolls back all local branches when one already exists locally") {

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolverTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/NextVersionResolverTest.kt
@@ -51,6 +51,44 @@ class NextVersionResolverTest : FunSpec({
         result shouldBe SemanticVersion(1, 0, 0)
     }
 
+    // ── forMainBranch with minimumVersion ─────────────────────────
+
+    test("forMainBranch with no prior tags and minimumVersion bumps from minimum") {
+        // given — adopting plugin on a project whose latest external release is 1.2.3
+        val latestVersion: SemanticVersion? = null
+        val minimumVersion = SemanticVersion(1, 2, 3)
+
+        // when
+        val result = NextVersionResolver.forMainBranch(latestVersion, Scope.MINOR, minimumVersion)
+
+        // then — should bump minor from 1.2.3 → 1.3.0
+        result shouldBe SemanticVersion(1, 3, 0)
+    }
+
+    test("forMainBranch with no prior tags and minimumVersion bumps major from minimum") {
+        // given
+        val latestVersion: SemanticVersion? = null
+        val minimumVersion = SemanticVersion(1, 2, 3)
+
+        // when
+        val result = NextVersionResolver.forMainBranch(latestVersion, Scope.MAJOR, minimumVersion)
+
+        // then — should bump major from 1.2.3 → 2.0.0
+        result shouldBe SemanticVersion(2, 0, 0)
+    }
+
+    test("forMainBranch with existing tags above minimumVersion ignores minimum") {
+        // given — plugin tags already exceed the minimum
+        val latestVersion = SemanticVersion(3, 0, 0)
+        val minimumVersion = SemanticVersion(1, 2, 3)
+
+        // when
+        val result = NextVersionResolver.forMainBranch(latestVersion, Scope.MINOR, minimumVersion)
+
+        // then — tags win, bumps from 3.0.0 → 3.1.0
+        result shouldBe SemanticVersion(3, 1, 0)
+    }
+
     // ── forReleaseBranch ─────────────────────────────────────────
 
     test("forReleaseBranch with no prior tags in version line returns major.minor.0") {


### PR DESCRIPTION
## Summary

- Adds a per-project `minimumVersion` DSL property to `MonorepoReleaseConfigExtension` that acts as a version floor when computing the next release version
- Supports the adoption scenario where a project has existing released versions from a different release mechanism and the plugin needs to start versioning past them
- Validates the value at release time (not configuration phase), failing with a clear error for invalid semver strings

## Usage

```kotlin
monorepoProject {
    release {
        enabled = true
        minimumVersion = "1.2.3"  // never produce a version below this
    }
}
```

With `minimumVersion = "1.2.3"` and minor scope, the first release branch will be `release/app/v1.3.x`.

Closes #150

## Test plan

- [x] Unit tests: `NextVersionResolverTest` — adoption scenario (no tags + minimum), major scope, tags-above-minimum
- [x] Integration test: `ReleaseBranchCreatorIntegrationTest` — no tags + minimumVersion creates correct branch
- [x] Functional tests: `ReleaseChangedFunctionalTest` — end-to-end adoption scenario, invalid minimumVersion error
- [x] Full `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)