### PR TITLE
feat: add dev release support for experimental branch builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ GitChangedFilesDetector  →  ProjectFileMapper  →  ProjectMetadataFactory  �
 | `release/git/GitReleaseExecutor` | Pushes tags and release branches via git; supports atomic multi-ref push |
 | `release/git/ReleaseBranchCreator` | Two-phase release branch creation: create locally → `git push --atomic` → rollback on failure; scans tags and branches for version resolution |
 | `build/git/LastSuccessfulBuildTagUpdater` | Force-updates and pushes the last-successful-build tag after successful builds |
+| `release/domain/DevTagPattern` | Formatting, parsing, and validation for dev branch/tag naming conventions (`dev/<project>/<name>/<N>`) |
+| `release/git/DevTagScanner` | Scans remote for dev release tags and branches via `git ls-remote` |
+| `release/task/CreateDevBranchTask` | Creates a dev branch for a subproject and pushes it; validates name and checks for conflicts |
+| `release/task/DevReleaseTask` | Creates incrementing dev release tags from a dev branch; writes `release-version.txt` |
 | `git/GitCommandExecutor` | Low-level `ProcessBuilder` wrapper for executing git commands |
 
 **Root project special case**: The root project is marked as changed only when files in the root directory (not inside any subproject directory) have changed.
@@ -79,6 +83,8 @@ The functional tests use a standard 5-module dependency tree (`common-lib` ← `
 | `ReleaseTaskFunctionalTest.kt` | `release` (per-subproject) |
 | `PerProjectBuildChangedFunctionalTest.kt` | `:sub:buildChanged` (per-subproject) |
 | `ReleaseChangedFunctionalTest.kt` | `releaseChanged` |
+| `CreateDevBranchFunctionalTest.kt` | `createDevBranch` (per-subproject) |
+| `DevReleaseFunctionalTest.kt` | `devRelease` (per-subproject) |
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,7 @@ Create a dedicated dev branch for a subproject:
 ./gradlew :app:createDevBranch -Pdev.branch.name=feature-auth
 ```
 
-This creates and pushes a branch named `dev/app/feature-auth`. The branch name must start with a letter or digit and contain only letters, digits, `.`, `_`, or `-`. Multiple dev branches can exist per project simultaneously.
-
-`createDevBranch` does not require `release { enabled = true }` — any subproject can create a dev branch.
+This creates and pushes a branch named `dev/app/feature-auth`. The branch name must start with a letter or digit and contain only letters, digits, `.`, `_`, or `-`. Multiple dev branches can exist per project simultaneously. Requires `release { enabled = true }` on the subproject.
 
 #### `:subproject:devRelease`
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,70 @@ Releases a single subproject from its release branch for patch releases. Must be
 
 The task will fail if run from `main`, a feature branch, or a release branch belonging to a different project.
 
+### Dev Releases
+
+Dev releases let you build and release experimental features from non-main branches for staging or testing. They are completely decoupled from stable versioning — no semver, no release branches, just simple incrementing tags.
+
+#### Creating a dev branch
+
+Create a dedicated dev branch for a subproject:
+
+```bash
+./gradlew :app:createDevBranch -Pdev.branch.name=feature-auth
+```
+
+This creates and pushes a branch named `dev/app/feature-auth`. The branch name must start with a letter or digit and contain only letters, digits, `.`, `_`, or `-`. Multiple dev branches can exist per project simultaneously.
+
+`createDevBranch` does not require `release { enabled = true }` — any subproject can create a dev branch.
+
+#### `:subproject:devRelease`
+
+Creates a dev release tag from a dev branch. Must be run from a matching dev branch (e.g., `:app:devRelease` must be run from `dev/app/<name>`):
+
+```bash
+./gradlew :app:devRelease
+```
+
+The task:
+1. Builds the project (always — no change detection)
+2. Scans existing dev tags and auto-increments the number
+3. Creates a tag like `dev/app/feature-auth/1` (then `/2`, `/3`, etc.)
+4. Writes the version to `build/release-version.txt` (e.g., `feature-auth.1`)
+
+Requires `release { enabled = true }` on the subproject.
+
+#### Dev release naming conventions
+
+| Element | Format | Example |
+|---------|--------|---------|
+| Branch | `dev/<project-prefix>/<name>` | `dev/app/feature-auth` |
+| Tag | `dev/<project-prefix>/<name>/<N>` | `dev/app/feature-auth/1` |
+| Version | `<name>.<N>` | `feature-auth.1` |
+
+The project prefix is derived the same way as stable releases — from `tagPrefix` config or Gradle path.
+
+#### Dev release workflow
+
+```bash
+# 1. Create the dev branch
+./gradlew :app:createDevBranch -Pdev.branch.name=feature-auth
+
+# 2. Check out the branch, make changes
+git checkout dev/app/feature-auth
+# ... develop, commit, push ...
+
+# 3. Release from the dev branch (CI or manual)
+./gradlew :app:devRelease
+# → tag: dev/app/feature-auth/1, version: feature-auth.1
+
+# 4. Continue developing and releasing
+# ... more commits ...
+./gradlew :app:devRelease
+# → tag: dev/app/feature-auth/2, version: feature-auth.2
+
+# 5. When ready, merge to main and use the normal release flow
+```
+
 ### Versioning rules
 
 - Release branches follow the pattern `{globalTagPrefix}/{projectPrefix}/v{major}.{minor}.x`
@@ -429,6 +493,7 @@ Command-line properties passed via `-P`:
 | Property | Applies To | Description |
 |----------|-----------|-------------|
 | `monorepo.targetBranch` | `buildChanged`, `printChanged`, per-project `buildChanged` | Overrides the default `origin/{primaryBranch}` baseline with `origin/{value}`. Accepts both `release/v1.x` and `origin/release/v1.x`. The branch is fetched from origin if not available locally. If the ref doesn't exist, all projects are treated as changed. Has no effect on `releaseChanged`. |
+| `dev.branch.name` | `createDevBranch` | Name for the dev branch (e.g., `feature-auth`). Required. Must start with a letter or digit and contain only letters, digits, `.`, `_`, or `-`. |
 
 ## Troubleshooting
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -68,7 +68,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
             val projectExtension = sub.extensions.findByType(MonorepoProjectExtension::class.java)
                 ?: sub.extensions.create("monorepoProject", MonorepoProjectExtension::class.java)
             registerReleaseTasks(sub, rootReleaseExtension, projectExtension.release)
-            registerDevReleaseTasks(sub, projectExtension.release)
+            registerDevReleaseTasks(sub, rootExtension, projectExtension.release)
         }
 
         // Register per-subproject buildChanged tasks eagerly.
@@ -514,6 +514,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
 
     private fun registerDevReleaseTasks(
         sub: Project,
+        rootExtension: MonorepoExtension,
         config: MonorepoReleaseConfigExtension
     ) {
         val executor = GitCommandExecutor(sub.logger)
@@ -528,6 +529,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
             this.projectPath = sub.path
             this.projectConfig = config
             this.devBranchNameProperty = sub.findProperty("dev.branch.name") as? String
+            this.primaryBranch = rootExtension.primaryBranch
         }
 
         sub.tasks.register("devRelease", DevReleaseTask::class.java) {

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -13,7 +13,10 @@ import io.github.doughawley.monorepo.release.MonorepoReleaseExtension
 import io.github.doughawley.monorepo.release.domain.Scope
 import io.github.doughawley.monorepo.release.domain.SemanticVersion
 import io.github.doughawley.monorepo.release.domain.TagPattern
+import io.github.doughawley.monorepo.release.git.DevTagScanner
 import io.github.doughawley.monorepo.release.git.ReleaseBranchCreator
+import io.github.doughawley.monorepo.release.task.CreateDevBranchTask
+import io.github.doughawley.monorepo.release.task.DevReleaseTask
 import io.github.doughawley.monorepo.release.task.ReleaseTask
 import io.github.doughawley.monorepo.git.GitCommandExecutor
 import io.github.doughawley.monorepo.release.git.GitReleaseExecutor
@@ -65,6 +68,7 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
             val projectExtension = sub.extensions.findByType(MonorepoProjectExtension::class.java)
                 ?: sub.extensions.create("monorepoProject", MonorepoProjectExtension::class.java)
             registerReleaseTasks(sub, rootReleaseExtension, projectExtension.release)
+            registerDevReleaseTasks(sub, projectExtension.release)
         }
 
         // Register per-subproject buildChanged tasks eagerly.
@@ -505,6 +509,36 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
             this.buildDir.set(sub.layout.buildDirectory)
             this.releaseScopeProperty = sub.findProperty("release.scope") as? String
             dependsOn("build", "buildChanged")
+        }
+    }
+
+    private fun registerDevReleaseTasks(
+        sub: Project,
+        config: MonorepoReleaseConfigExtension
+    ) {
+        val executor = GitCommandExecutor(sub.logger)
+        val devTagScanner = DevTagScanner(sub.rootProject.rootDir, executor)
+        val releaseExecutor = GitReleaseExecutor(sub.rootProject.rootDir, executor, sub.logger)
+
+        sub.tasks.register("createDevBranch", CreateDevBranchTask::class.java) {
+            group = TASK_GROUP
+            description = "Creates a dev branch for this project"
+            this.gitReleaseExecutor = releaseExecutor
+            this.devTagScanner = devTagScanner
+            this.projectPath = sub.path
+            this.projectConfig = config
+            this.devBranchNameProperty = sub.findProperty("dev.branch.name") as? String
+        }
+
+        sub.tasks.register("devRelease", DevReleaseTask::class.java) {
+            group = TASK_GROUP
+            description = "Creates a dev release tag for this project"
+            this.gitReleaseExecutor = releaseExecutor
+            this.devTagScanner = devTagScanner
+            this.projectPath = sub.path
+            this.projectConfig = config
+            this.buildDir.set(sub.layout.buildDirectory)
+            dependsOn("build")
         }
     }
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/domain/DevTagPattern.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/domain/DevTagPattern.kt
@@ -1,0 +1,93 @@
+package io.github.doughawley.monorepo.release.domain
+
+import org.gradle.api.GradleException
+
+/**
+ * Naming conventions for dev branches and tags.
+ *
+ * Dev releases use a simple incrementing integer instead of semver,
+ * and are completely decoupled from stable release versioning.
+ *
+ * Branch format: `dev/<projectPrefix>/<branchName>`
+ * Tag format:    `dev/<projectPrefix>/<branchName>/<number>`
+ * Version:       `<branchName>.<number>`
+ */
+object DevTagPattern {
+
+    private val VALID_BRANCH_NAME = Regex("^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+    fun formatDevBranch(projectPrefix: String, branchName: String): String {
+        return "dev/$projectPrefix/$branchName"
+    }
+
+    fun formatDevTag(projectPrefix: String, branchName: String, number: Int): String {
+        return "dev/$projectPrefix/$branchName/$number"
+    }
+
+    fun formatDevVersion(branchName: String, number: Int): String {
+        return "$branchName.$number"
+    }
+
+    fun isDevBranch(branch: String): Boolean {
+        return Regex("^dev/.+/.+$").matches(branch)
+    }
+
+    /**
+     * Parses a dev branch name into its project prefix and branch name components.
+     *
+     * The branch name is always the last path segment (slashes are not allowed
+     * in branch names), and the project prefix is everything between `dev/` and
+     * the last `/`. This handles nested project prefixes like `services/auth`.
+     *
+     * @return parsed info, or null if the branch does not match the dev branch format
+     */
+    fun parseDevBranch(branch: String): DevBranchInfo? {
+        if (!branch.startsWith("dev/")) return null
+        val withoutPrefix = branch.removePrefix("dev/")
+        val lastSlash = withoutPrefix.lastIndexOf('/')
+        if (lastSlash <= 0) return null
+        val projectPrefix = withoutPrefix.substring(0, lastSlash)
+        val branchName = withoutPrefix.substring(lastSlash + 1)
+        if (branchName.isEmpty()) return null
+        return DevBranchInfo(projectPrefix, branchName)
+    }
+
+    /**
+     * Extracts the integer tag number from a `git ls-remote` output line.
+     *
+     * @param tagRef a line from `git ls-remote`, e.g. `"<sha>\trefs/tags/dev/app/feature-auth/3"`
+     * @return the tag number, or null if the line does not match
+     */
+    fun parseDevTagNumber(tagRef: String, projectPrefix: String, branchName: String): Int? {
+        val expectedPrefix = "refs/tags/dev/$projectPrefix/$branchName/"
+        val refPart = tagRef.substringAfter("\t").trim()
+        if (!refPart.startsWith(expectedPrefix)) return null
+        val numberStr = refPart.removePrefix(expectedPrefix)
+        return numberStr.toIntOrNull()
+    }
+
+    /**
+     * Validates that a branch name is safe for use in git ref names and tag paths.
+     *
+     * @throws GradleException if the name is blank or contains disallowed characters
+     */
+    fun validateBranchName(name: String) {
+        if (name.isBlank()) {
+            throw GradleException(
+                "Dev branch name must not be blank. " +
+                "Usage: -Pdev.branch.name=<name>"
+            )
+        }
+        if (!VALID_BRANCH_NAME.matches(name)) {
+            throw GradleException(
+                "Invalid dev branch name '$name'. " +
+                "Must start with a letter or digit, and contain only letters, digits, '.', '_', or '-'."
+            )
+        }
+    }
+}
+
+data class DevBranchInfo(
+    val projectPrefix: String,
+    val branchName: String
+)

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/DevTagScanner.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/DevTagScanner.kt
@@ -1,0 +1,38 @@
+package io.github.doughawley.monorepo.release.git
+
+import io.github.doughawley.monorepo.git.GitCommandExecutor
+import io.github.doughawley.monorepo.release.domain.DevTagPattern
+import java.io.File
+
+/**
+ * Scans the remote for dev release tags and branches.
+ *
+ * Uses `git ls-remote` to query the remote, following the same
+ * authoritative-remote pattern as [GitTagScanner].
+ */
+class DevTagScanner(
+    private val rootDir: File,
+    private val executor: GitCommandExecutor
+) {
+
+    /**
+     * Returns the highest dev tag number for the given project and branch,
+     * or null if no dev tags exist on the remote.
+     */
+    fun findLatestDevTagNumber(projectPrefix: String, branchName: String): Int? {
+        val refPattern = "refs/tags/dev/$projectPrefix/$branchName/*"
+        val lines = executor.executeForOutput(rootDir, "ls-remote", "--tags", "--refs", "origin", refPattern)
+        return lines
+            .mapNotNull { DevTagPattern.parseDevTagNumber(it, projectPrefix, branchName) }
+            .maxOrNull()
+    }
+
+    /**
+     * Returns true if a dev branch for the given project and name exists on the remote.
+     */
+    fun devBranchExistsOnRemote(projectPrefix: String, branchName: String): Boolean {
+        val refPattern = "refs/heads/dev/$projectPrefix/$branchName"
+        val lines = executor.executeForOutput(rootDir, "ls-remote", "--heads", "origin", refPattern)
+        return lines.isNotEmpty()
+    }
+}

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/git/GitReleaseExecutor.kt
@@ -103,6 +103,14 @@ class GitReleaseExecutor(
         logger.lifecycle("Pushed ${refs.size} ref(s) atomically to remote")
     }
 
+    fun checkoutBranch(branch: String) {
+        val result = executor.execute(rootDir, "checkout", branch)
+        if (!result.success) {
+            throw GradleException("Failed to checkout branch '$branch': ${result.errorOutput}")
+        }
+        logger.lifecycle("Checked out branch: $branch")
+    }
+
     fun branchExistsLocally(branch: String): Boolean {
         val result = executor.execute(rootDir, "branch", "--list", branch)
         if (!result.success) {

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/CreateDevBranchTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/CreateDevBranchTask.kt
@@ -31,7 +31,15 @@ abstract class CreateDevBranchTask : DefaultTask() {
 
     @TaskAction
     fun createDevBranch() {
-        // 1. Validate branch name is provided
+        // 1. Opt-in check
+        if (!projectConfig.enabled) {
+            throw GradleException(
+                "Release is not enabled for $projectPath. " +
+                "Set monorepoProject { release { enabled = true } } to opt in."
+            )
+        }
+
+        // 2. Validate branch name is provided
         val branchName = devBranchNameProperty
         if (branchName.isNullOrBlank()) {
             throw GradleException(

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/CreateDevBranchTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/CreateDevBranchTask.kt
@@ -29,6 +29,9 @@ abstract class CreateDevBranchTask : DefaultTask() {
     @get:Internal
     var devBranchNameProperty: String? = null
 
+    @get:Internal
+    lateinit var primaryBranch: String
+
     @TaskAction
     fun createDevBranch() {
         // 1. Opt-in check
@@ -39,7 +42,16 @@ abstract class CreateDevBranchTask : DefaultTask() {
             )
         }
 
-        // 2. Validate branch name is provided
+        // 2. Branch guard — must be on primaryBranch
+        val currentBranch = gitReleaseExecutor.currentBranch()
+        if (currentBranch != primaryBranch) {
+            throw GradleException(
+                "createDevBranch must be run from '$primaryBranch', " +
+                "but the current branch is '$currentBranch'."
+            )
+        }
+
+        // 3. Validate branch name is provided
         val branchName = devBranchNameProperty
         if (branchName.isNullOrBlank()) {
             throw GradleException(
@@ -48,17 +60,17 @@ abstract class CreateDevBranchTask : DefaultTask() {
             )
         }
 
-        // 2. Validate branch name characters
+        // 4. Validate branch name characters
         DevTagPattern.validateBranchName(branchName)
 
-        // 3. Determine project prefix
+        // 5. Determine project prefix
         val projectPrefix = projectConfig.tagPrefix
             ?: TagPattern.deriveProjectTagPrefix(projectPath)
 
-        // 4. Format the full branch name
+        // 6. Format the full branch name
         val fullBranch = DevTagPattern.formatDevBranch(projectPrefix, branchName)
 
-        // 5. Check remote for existing branch
+        // 7. Check remote for existing branch
         if (devTagScanner.devBranchExistsOnRemote(projectPrefix, branchName)) {
             throw GradleException(
                 "Dev branch '$fullBranch' already exists on the remote. " +
@@ -66,7 +78,7 @@ abstract class CreateDevBranchTask : DefaultTask() {
             )
         }
 
-        // 6. Check local for existing branch
+        // 8. Check local for existing branch
         if (gitReleaseExecutor.branchExistsLocally(fullBranch)) {
             throw GradleException(
                 "Dev branch '$fullBranch' already exists locally. " +
@@ -74,10 +86,10 @@ abstract class CreateDevBranchTask : DefaultTask() {
             )
         }
 
-        // 7. Create branch locally
+        // 9. Create branch locally
         gitReleaseExecutor.createBranchLocally(fullBranch)
 
-        // 8. Push to remote (with rollback on failure)
+        // 10. Push to remote (with rollback on failure)
         try {
             gitReleaseExecutor.pushBranch(fullBranch)
         } catch (e: GradleException) {
@@ -85,6 +97,9 @@ abstract class CreateDevBranchTask : DefaultTask() {
             gitReleaseExecutor.deleteLocalBranch(fullBranch)
             throw e
         }
+
+        // 11. Check out the new branch so the developer is ready to work
+        gitReleaseExecutor.checkoutBranch(fullBranch)
 
         logger.lifecycle("Created dev branch: $fullBranch")
     }

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/CreateDevBranchTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/CreateDevBranchTask.kt
@@ -1,0 +1,83 @@
+package io.github.doughawley.monorepo.release.task
+
+import io.github.doughawley.monorepo.release.MonorepoReleaseConfigExtension
+import io.github.doughawley.monorepo.release.domain.DevTagPattern
+import io.github.doughawley.monorepo.release.domain.TagPattern
+import io.github.doughawley.monorepo.release.git.DevTagScanner
+import io.github.doughawley.monorepo.release.git.GitReleaseExecutor
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "Creates git branches and pushes to remote")
+abstract class CreateDevBranchTask : DefaultTask() {
+
+    @get:Internal
+    lateinit var gitReleaseExecutor: GitReleaseExecutor
+
+    @get:Internal
+    lateinit var devTagScanner: DevTagScanner
+
+    @get:Internal
+    lateinit var projectPath: String
+
+    @get:Internal
+    lateinit var projectConfig: MonorepoReleaseConfigExtension
+
+    @get:Internal
+    var devBranchNameProperty: String? = null
+
+    @TaskAction
+    fun createDevBranch() {
+        // 1. Validate branch name is provided
+        val branchName = devBranchNameProperty
+        if (branchName.isNullOrBlank()) {
+            throw GradleException(
+                "The -Pdev.branch.name property is required. " +
+                "Usage: ./gradlew $projectPath:createDevBranch -Pdev.branch.name=<name>"
+            )
+        }
+
+        // 2. Validate branch name characters
+        DevTagPattern.validateBranchName(branchName)
+
+        // 3. Determine project prefix
+        val projectPrefix = projectConfig.tagPrefix
+            ?: TagPattern.deriveProjectTagPrefix(projectPath)
+
+        // 4. Format the full branch name
+        val fullBranch = DevTagPattern.formatDevBranch(projectPrefix, branchName)
+
+        // 5. Check remote for existing branch
+        if (devTagScanner.devBranchExistsOnRemote(projectPrefix, branchName)) {
+            throw GradleException(
+                "Dev branch '$fullBranch' already exists on the remote. " +
+                "Choose a different name or delete the existing branch first."
+            )
+        }
+
+        // 6. Check local for existing branch
+        if (gitReleaseExecutor.branchExistsLocally(fullBranch)) {
+            throw GradleException(
+                "Dev branch '$fullBranch' already exists locally. " +
+                "Delete it manually or choose a different name."
+            )
+        }
+
+        // 7. Create branch locally
+        gitReleaseExecutor.createBranchLocally(fullBranch)
+
+        // 8. Push to remote (with rollback on failure)
+        try {
+            gitReleaseExecutor.pushBranch(fullBranch)
+        } catch (e: GradleException) {
+            logger.error("Push failed, rolling back local branch: ${e.message}")
+            gitReleaseExecutor.deleteLocalBranch(fullBranch)
+            throw e
+        }
+
+        logger.lifecycle("Created dev branch: $fullBranch")
+    }
+}

--- a/src/main/kotlin/io/github/doughawley/monorepo/release/task/DevReleaseTask.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/release/task/DevReleaseTask.kt
@@ -1,0 +1,114 @@
+package io.github.doughawley.monorepo.release.task
+
+import io.github.doughawley.monorepo.release.MonorepoReleaseConfigExtension
+import io.github.doughawley.monorepo.release.domain.DevTagPattern
+import io.github.doughawley.monorepo.release.domain.TagPattern
+import io.github.doughawley.monorepo.release.git.DevTagScanner
+import io.github.doughawley.monorepo.release.git.GitReleaseExecutor
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "Creates git tags and pushes to remote")
+abstract class DevReleaseTask : DefaultTask() {
+
+    @get:Internal
+    lateinit var gitReleaseExecutor: GitReleaseExecutor
+
+    @get:Internal
+    lateinit var devTagScanner: DevTagScanner
+
+    @get:Internal
+    lateinit var projectPath: String
+
+    @get:Internal
+    lateinit var projectConfig: MonorepoReleaseConfigExtension
+
+    @get:Internal
+    abstract val buildDir: DirectoryProperty
+
+    @TaskAction
+    fun devRelease() {
+        // 1. Opt-in check
+        if (!projectConfig.enabled) {
+            throw GradleException(
+                "Release is not enabled for $projectPath. " +
+                "Set monorepoProject { release { enabled = true } } to opt in."
+            )
+        }
+
+        // 2. Dirty check
+        if (gitReleaseExecutor.isDirty()) {
+            throw GradleException(
+                "Cannot release with uncommitted changes. " +
+                "Please commit or stash all changes before releasing."
+            )
+        }
+
+        // 3. Branch validation — must be on a dev branch
+        val currentBranch = gitReleaseExecutor.currentBranch()
+        if (currentBranch == "HEAD") {
+            throw GradleException(
+                "Cannot create a dev release from a detached HEAD state. " +
+                "Check out a dev branch before releasing."
+            )
+        }
+        val branchInfo = DevTagPattern.parseDevBranch(currentBranch)
+            ?: throw GradleException(
+                "Cannot create a dev release from branch '$currentBranch'. " +
+                "Dev releases must be made from a dev branch " +
+                "(e.g., dev/<project>/<name>)."
+            )
+
+        // 4. Project-to-branch validation
+        val expectedPrefix = projectConfig.tagPrefix
+            ?: TagPattern.deriveProjectTagPrefix(projectPath)
+        if (branchInfo.projectPrefix != expectedPrefix) {
+            throw GradleException(
+                "Cannot create a dev release for $projectPath from branch '$currentBranch'. " +
+                "This branch is for project '${branchInfo.projectPrefix}', not '$expectedPrefix'."
+            )
+        }
+
+        // 5. Build outputs check
+        val libsDir = buildDir.dir("libs").get().asFile
+        val libsFiles = libsDir.listFiles()
+        if (!libsDir.exists() || libsFiles == null || libsFiles.isEmpty()) {
+            throw GradleException(
+                "Project must be built before releasing — run $projectPath:build first."
+            )
+        }
+
+        // 6. Scan for latest dev tag number and increment
+        val latestNumber = devTagScanner.findLatestDevTagNumber(branchInfo.projectPrefix, branchInfo.branchName)
+        val nextNumber = (latestNumber ?: 0) + 1
+
+        // 7. Format tag
+        val tag = DevTagPattern.formatDevTag(branchInfo.projectPrefix, branchInfo.branchName, nextNumber)
+        val version = DevTagPattern.formatDevVersion(branchInfo.branchName, nextNumber)
+
+        logger.lifecycle("Dev releasing $projectPath as version $version")
+
+        // 8. Create tag locally
+        gitReleaseExecutor.createTagLocally(tag)
+
+        // 9. Push to remote (with rollback on failure)
+        try {
+            gitReleaseExecutor.pushTag(tag)
+        } catch (e: GradleException) {
+            logger.error("Push failed, rolling back local tag: ${e.message}")
+            gitReleaseExecutor.deleteLocalTag(tag)
+            throw e
+        }
+
+        // 10. Write build/release-version.txt
+        val versionFile = buildDir.file("release-version.txt").get().asFile
+        versionFile.parentFile.mkdirs()
+        versionFile.writeText(version)
+        val relativePath = project.rootDir.toPath().relativize(versionFile.toPath())
+        logger.lifecycle("Wrote dev release version to: $relativePath")
+    }
+}

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateDevBranchFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateDevBranchFunctionalTest.kt
@@ -1,0 +1,202 @@
+package io.github.doughawley.monorepo.release.functional
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+
+class CreateDevBranchFunctionalTest : FunSpec({
+
+    val testListener = extension(ReleaseTestProjectListener())
+
+    test("creates dev branch and pushes it to remote") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+
+        // when
+        val result = project.runTask(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "feature-auth")
+        )
+
+        // then
+        result.task(":app:createDevBranch")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "dev/app/feature-auth"
+        project.localBranches() shouldContain "dev/app/feature-auth"
+    }
+
+    test("fails with clear message when dev.branch.name not provided") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+
+        // when
+        val result = project.runTaskAndFail(":app:createDevBranch")
+
+        // then
+        result.output shouldContain "-Pdev.branch.name"
+    }
+
+    test("fails with clear message when dev.branch.name is empty") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+
+        // when
+        val result = project.runTaskAndFail(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "")
+        )
+
+        // then
+        result.output shouldContain "dev.branch.name"
+    }
+
+    test("fails with clear message when branch name contains invalid characters") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+
+        // when
+        val result = project.runTaskAndFail(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "has space")
+        )
+
+        // then
+        result.output shouldContain "Invalid dev branch name"
+    }
+
+    test("fails when dev branch already exists on remote") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        pushBranch(project, "dev/app/feature-auth")
+        project.checkoutBranch("main")
+
+        // when
+        val result = project.runTaskAndFail(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "feature-auth")
+        )
+
+        // then
+        result.output shouldContain "already exists on the remote"
+    }
+
+    test("fails when dev branch already exists locally") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        project.checkoutBranch("main")
+
+        // when
+        val result = project.runTaskAndFail(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "feature-auth")
+        )
+
+        // then
+        result.output shouldContain "already exists locally"
+    }
+
+    test("works with custom tagPrefix") {
+        // given
+        val projectDir = testListener.getTestProjectDir()
+        val project = StandardReleaseTestProject.create(projectDir)
+        // Override app's build.gradle.kts to use custom tagPrefix
+        java.io.File(projectDir, "app/build.gradle.kts").writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = true
+                    tagPrefix = "my-custom-app"
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+
+        // when
+        val result = project.runTask(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "feature-auth")
+        )
+
+        // then
+        result.task(":app:createDevBranch")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "dev/my-custom-app/feature-auth"
+    }
+
+    test("does not require release enabled to create a dev branch") {
+        // given
+        val projectDir = testListener.getTestProjectDir()
+        val project = StandardReleaseTestProject.create(projectDir)
+        // Override app's build.gradle.kts to disable release
+        java.io.File(projectDir, "app/build.gradle.kts").writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = false
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+
+        // when
+        val result = project.runTask(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "feature-auth")
+        )
+
+        // then
+        result.task(":app:createDevBranch")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "dev/app/feature-auth"
+    }
+
+    test("fails when branch name starts with a dash") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+
+        // when
+        val result = project.runTaskAndFail(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "-bad-name")
+        )
+
+        // then
+        result.output shouldContain "Invalid dev branch name"
+    }
+})
+
+private fun pushBranch(project: ReleaseTestProject, branch: String) {
+    val process = ProcessBuilder("git", "push", "origin", branch)
+        .directory(project.projectDir)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+        val error = process.errorStream.bufferedReader().readText()
+        throw RuntimeException("Failed to push branch $branch: $error")
+    }
+}

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateDevBranchFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateDevBranchFunctionalTest.kt
@@ -136,7 +136,7 @@ class CreateDevBranchFunctionalTest : FunSpec({
         project.remoteBranches() shouldContain "dev/my-custom-app/feature-auth"
     }
 
-    test("does not require release enabled to create a dev branch") {
+    test("fails when release is not enabled") {
         // given
         val projectDir = testListener.getTestProjectDir()
         val project = StandardReleaseTestProject.create(projectDir)
@@ -163,14 +163,13 @@ class CreateDevBranchFunctionalTest : FunSpec({
         project.pushToRemote()
 
         // when
-        val result = project.runTask(
+        val result = project.runTaskAndFail(
             ":app:createDevBranch",
             properties = mapOf("dev.branch.name" to "feature-auth")
         )
 
         // then
-        result.task(":app:createDevBranch")?.outcome shouldBe TaskOutcome.SUCCESS
-        project.remoteBranches() shouldContain "dev/app/feature-auth"
+        result.output shouldContain "Release is not enabled"
     }
 
     test("fails when branch name starts with a dash") {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateDevBranchFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/CreateDevBranchFunctionalTest.kt
@@ -10,7 +10,7 @@ class CreateDevBranchFunctionalTest : FunSpec({
 
     val testListener = extension(ReleaseTestProjectListener())
 
-    test("creates dev branch and pushes it to remote") {
+    test("creates dev branch, pushes to remote, and checks out the branch") {
         // given
         val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
 
@@ -24,6 +24,7 @@ class CreateDevBranchFunctionalTest : FunSpec({
         result.task(":app:createDevBranch")?.outcome shouldBe TaskOutcome.SUCCESS
         project.remoteBranches() shouldContain "dev/app/feature-auth"
         project.localBranches() shouldContain "dev/app/feature-auth"
+        project.currentBranch() shouldBe "dev/app/feature-auth"
     }
 
     test("fails with clear message when dev.branch.name not provided") {
@@ -170,6 +171,21 @@ class CreateDevBranchFunctionalTest : FunSpec({
 
         // then
         result.output shouldContain "Release is not enabled"
+    }
+
+    test("fails when not on primary branch") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("feature/something")
+
+        // when
+        val result = project.runTaskAndFail(
+            ":app:createDevBranch",
+            properties = mapOf("dev.branch.name" to "feature-auth")
+        )
+
+        // then
+        result.output shouldContain "must be run from 'main'"
     }
 
     test("fails when branch name starts with a dash") {

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/DevReleaseFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/DevReleaseFunctionalTest.kt
@@ -1,0 +1,253 @@
+package io.github.doughawley.monorepo.release.functional
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+class DevReleaseFunctionalTest : FunSpec({
+
+    val testListener = extension(ReleaseTestProjectListener())
+
+    test("creates first dev tag when no prior dev tags exist") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// changed")
+        project.commitAll("dev work")
+        pushBranch(project, "dev/app/feature-auth")
+
+        // when
+        val result = project.runTask(":app:devRelease")
+
+        // then
+        result.task(":app:devRelease")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteTags() shouldContain "dev/app/feature-auth/1"
+    }
+
+    test("increments tag number when prior dev tags exist") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// changed")
+        project.commitAll("dev work")
+        pushBranch(project, "dev/app/feature-auth")
+
+        // Create prior dev tags on remote
+        project.createTag("dev/app/feature-auth/1")
+        project.pushTag("dev/app/feature-auth/1")
+        project.createTag("dev/app/feature-auth/2")
+        project.pushTag("dev/app/feature-auth/2")
+
+        // when
+        val result = project.runTask(":app:devRelease")
+
+        // then
+        result.task(":app:devRelease")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteTags() shouldContain "dev/app/feature-auth/3"
+    }
+
+    test("writes correct version to release-version.txt") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// changed")
+        project.commitAll("dev work")
+        pushBranch(project, "dev/app/feature-auth")
+
+        // when
+        project.runTask(":app:devRelease")
+
+        // then
+        project.releaseVersionFile() shouldBe "feature-auth.1"
+    }
+
+    test("depends on build task") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// changed")
+        project.commitAll("dev work")
+        pushBranch(project, "dev/app/feature-auth")
+
+        // when
+        val result = project.runTask(":app:devRelease")
+
+        // then
+        result.task(":app:build")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":app:devRelease")?.outcome shouldBe TaskOutcome.SUCCESS
+    }
+
+    test("fails when not on a dev branch") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTaskAndFail(":app:devRelease")
+
+        // then
+        result.output shouldContain "Dev releases must be made from a dev branch"
+    }
+
+    test("fails when on a dev branch for a different project") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/other-project/feature-auth")
+        project.createFakeBuiltArtifact()
+
+        // when
+        val result = project.runTaskAndFail(":app:devRelease")
+
+        // then
+        result.output shouldContain "not 'app'"
+    }
+
+    test("fails when working tree is dirty") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        pushBranch(project, "dev/app/feature-auth")
+        project.createFakeBuiltArtifact()
+        // Dirty the working tree after build
+        project.modifyFile("app/dirty.txt", "uncommitted change")
+
+        // when
+        val result = project.runTaskAndFail(":app:devRelease")
+
+        // then
+        result.output shouldContain "uncommitted changes"
+    }
+
+    test("fails when release is not enabled") {
+        // given
+        val projectDir = testListener.getTestProjectDir()
+        val project = StandardReleaseTestProject.create(projectDir)
+        // Override app's build.gradle.kts to disable release
+        File(projectDir, "app/build.gradle.kts").writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = false
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+        project.createBranch("dev/app/feature-auth")
+        pushBranch(project, "dev/app/feature-auth")
+
+        // when
+        val result = project.runTaskAndFail(":app:devRelease")
+
+        // then
+        result.output shouldContain "Release is not enabled"
+    }
+
+    test("fails when on detached HEAD") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createFakeBuiltArtifact()
+        project.detachHead()
+
+        // when
+        val result = project.runTaskAndFail(":app:devRelease")
+
+        // then
+        result.output shouldContain "detached HEAD"
+    }
+
+    test("multiple dev releases increment correctly") {
+        // given
+        val project = StandardReleaseTestProject.createAndInitialize(testListener.getTestProjectDir())
+        project.createBranch("dev/app/feature-auth")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// v1")
+        project.commitAll("dev work 1")
+        pushBranch(project, "dev/app/feature-auth")
+
+        // when — first release
+        project.runTask(":app:devRelease")
+        project.releaseVersionFile() shouldBe "feature-auth.1"
+
+        // second release
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// v2")
+        project.commitAll("dev work 2")
+        project.runTask(":app:devRelease")
+        project.releaseVersionFile() shouldBe "feature-auth.2"
+
+        // third release
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// v3")
+        project.commitAll("dev work 3")
+        project.runTask(":app:devRelease")
+
+        // then
+        project.releaseVersionFile() shouldBe "feature-auth.3"
+        project.remoteTags() shouldContain "dev/app/feature-auth/1"
+        project.remoteTags() shouldContain "dev/app/feature-auth/2"
+        project.remoteTags() shouldContain "dev/app/feature-auth/3"
+    }
+
+    test("works with custom tagPrefix") {
+        // given
+        val projectDir = testListener.getTestProjectDir()
+        val project = StandardReleaseTestProject.create(projectDir)
+        File(projectDir, "app/build.gradle.kts").writeText(
+            """
+            monorepoProject {
+                release {
+                    enabled = true
+                    tagPrefix = "my-custom-app"
+                }
+            }
+
+            tasks.register("build") {
+                doLast {
+                    val libsDir = layout.buildDirectory.dir("libs").get().asFile
+                    libsDir.mkdirs()
+                    java.io.File(libsDir, "${'$'}{project.name}.jar").writeText("built artifact")
+                }
+            }
+            """.trimIndent()
+        )
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+        project.createBranch("dev/my-custom-app/feature-auth")
+        project.modifyFile("app/src/main/kotlin/com/example/App.kt", "// changed")
+        project.commitAll("dev work")
+        pushBranch(project, "dev/my-custom-app/feature-auth")
+
+        // when
+        val result = project.runTask(":app:devRelease")
+
+        // then
+        result.task(":app:devRelease")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteTags() shouldContain "dev/my-custom-app/feature-auth/1"
+        project.releaseVersionFile() shouldBe "feature-auth.1"
+    }
+})
+
+private fun pushBranch(project: ReleaseTestProject, branch: String) {
+    val process = ProcessBuilder("git", "push", "origin", branch)
+        .directory(project.projectDir)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+        val error = process.errorStream.bufferedReader().readText()
+        throw RuntimeException("Failed to push branch $branch: $error")
+    }
+}

--- a/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/DevTagScannerIntegrationTest.kt
+++ b/src/test/integration/kotlin/io/github/doughawley/monorepo/release/git/DevTagScannerIntegrationTest.kt
@@ -1,0 +1,132 @@
+package io.github.doughawley.monorepo.release.git
+
+import io.github.doughawley.monorepo.git.GitCommandExecutor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.api.logging.Logger
+
+class DevTagScannerIntegrationTest : FunSpec({
+
+    val repoListener = TempGitRepoListener()
+    extension(repoListener)
+
+    val logger = mockk<Logger>(relaxed = true)
+
+    // findLatestDevTagNumber
+
+    test("findLatestDevTagNumber returns null when remote has no dev tags") {
+        // given
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result.shouldBeNull()
+    }
+
+    test("findLatestDevTagNumber returns the single tag number pushed to remote") {
+        // given
+        repoListener.repo.pushTag("dev/app/feature-auth/1")
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result shouldBe 1
+    }
+
+    test("findLatestDevTagNumber returns the maximum number when multiple tags exist") {
+        // given
+        repoListener.repo.pushTag("dev/app/feature-auth/1")
+        repoListener.repo.pushTag("dev/app/feature-auth/2")
+        repoListener.repo.pushTag("dev/app/feature-auth/3")
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result shouldBe 3
+    }
+
+    test("findLatestDevTagNumber ignores dev tags for a different project prefix") {
+        // given
+        repoListener.repo.pushTag("dev/other-app/feature-auth/5")
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result.shouldBeNull()
+    }
+
+    test("findLatestDevTagNumber ignores dev tags for a different branch name") {
+        // given
+        repoListener.repo.pushTag("dev/app/other-branch/5")
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result.shouldBeNull()
+    }
+
+    test("findLatestDevTagNumber does not return local-only tags") {
+        // given
+        repoListener.repo.createLocalTag("dev/app/feature-auth/1")
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result.shouldBeNull()
+    }
+
+    // devBranchExistsOnRemote
+
+    test("devBranchExistsOnRemote returns true when branch is pushed") {
+        // given
+        repoListener.repo.checkoutNewBranch("dev/app/feature-auth")
+        repoListener.repo.createUntrackedFile("dev-file.txt")
+        repoListener.repo.commitAll("dev branch commit")
+        val executor = GitCommandExecutor(logger)
+        executor.executeForOutput(repoListener.repo.localDir, "push", "origin", "dev/app/feature-auth")
+        val scanner = DevTagScanner(repoListener.repo.localDir, executor)
+
+        // when
+        val result = scanner.devBranchExistsOnRemote("app", "feature-auth")
+
+        // then
+        result shouldBe true
+    }
+
+    test("devBranchExistsOnRemote returns false when branch only exists locally") {
+        // given
+        repoListener.repo.checkoutNewBranch("dev/app/feature-auth")
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.devBranchExistsOnRemote("app", "feature-auth")
+
+        // then
+        result shouldBe false
+    }
+
+    test("devBranchExistsOnRemote returns false when no matching branch exists") {
+        // given
+        val scanner = DevTagScanner(repoListener.repo.localDir, GitCommandExecutor(logger))
+
+        // when
+        val result = scanner.devBranchExistsOnRemote("app", "feature-auth")
+
+        // then
+        result shouldBe false
+    }
+})

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/DevTagPatternTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/DevTagPatternTest.kt
@@ -1,0 +1,162 @@
+package io.github.doughawley.monorepo.release.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.api.GradleException
+
+class DevTagPatternTest : FunSpec({
+
+    context("formatDevBranch produces dev/projectPrefix/branchName") {
+        withData(
+            Triple("app", "feature-auth", "dev/app/feature-auth"),
+            Triple("services/auth", "experiment", "dev/services/auth/experiment"),
+            Triple("apps/some_domain-v1", "JIRA-1234", "dev/apps/some_domain-v1/JIRA-1234"),
+        ) { (projectPrefix, branchName, expected) ->
+            DevTagPattern.formatDevBranch(projectPrefix, branchName) shouldBe expected
+        }
+    }
+
+    context("formatDevTag produces dev/projectPrefix/branchName/number") {
+        withData(
+            Triple("app", "feature-auth", 1) to "dev/app/feature-auth/1",
+            Triple("app", "feature-auth", 10) to "dev/app/feature-auth/10",
+            Triple("services/auth", "experiment", 100) to "dev/services/auth/experiment/100",
+        ) { (input, expected) ->
+            val (projectPrefix, branchName, number) = input
+            DevTagPattern.formatDevTag(projectPrefix, branchName, number) shouldBe expected
+        }
+    }
+
+    context("formatDevVersion produces branchName.number") {
+        withData(
+            Triple("feature-auth", 1, "feature-auth.1"),
+            Triple("feature-auth", 2, "feature-auth.2"),
+            Triple("JIRA-1234", 5, "JIRA-1234.5"),
+        ) { (branchName, number, expected) ->
+            DevTagPattern.formatDevVersion(branchName, number) shouldBe expected
+        }
+    }
+
+    context("isDevBranch returns true for valid dev branches") {
+        withData(
+            "dev/app/feature-auth",
+            "dev/services/auth/experiment",
+            "dev/a/b",
+        ) { branch ->
+            DevTagPattern.isDevBranch(branch) shouldBe true
+        }
+    }
+
+    context("isDevBranch returns false for non-dev branches") {
+        withData(
+            "main",
+            "master",
+            "feature/my-feature",
+            "release/app/v1.0.x",
+            "dev",
+            "dev/app",
+        ) { branch ->
+            DevTagPattern.isDevBranch(branch) shouldBe false
+        }
+    }
+
+    context("parseDevBranch extracts projectPrefix and branchName") {
+        withData(
+            "dev/app/feature-auth" to DevBranchInfo("app", "feature-auth"),
+            "dev/services/auth/feature-x" to DevBranchInfo("services/auth", "feature-x"),
+            "dev/a/b/c/my-branch" to DevBranchInfo("a/b/c", "my-branch"),
+        ) { (branch, expected) ->
+            DevTagPattern.parseDevBranch(branch) shouldBe expected
+        }
+    }
+
+    context("parseDevBranch returns null for non-dev branches") {
+        withData(
+            "main",
+            "release/app/v1.0.x",
+            "dev",
+            "dev/app",
+            "dev/app/",
+            "notdev/app/feature",
+        ) { branch ->
+            DevTagPattern.parseDevBranch(branch).shouldBeNull()
+        }
+    }
+
+    context("parseDevTagNumber extracts integer from ls-remote output") {
+        withData(
+            Triple("abc123\trefs/tags/dev/app/feature-auth/1", "app", "feature-auth") to 1,
+            Triple("def456\trefs/tags/dev/app/feature-auth/42", "app", "feature-auth") to 42,
+            Triple("ghi789\trefs/tags/dev/services/auth/exp/3", "services/auth", "exp") to 3,
+        ) { (input, expected) ->
+            val (tagRef, projectPrefix, branchName) = input
+            DevTagPattern.parseDevTagNumber(tagRef, projectPrefix, branchName) shouldBe expected
+        }
+    }
+
+    context("parseDevTagNumber returns null for non-matching refs") {
+        withData(
+            "abc123\trefs/tags/dev/other/feature-auth/1",
+            "abc123\trefs/tags/dev/app/other-branch/1",
+            "abc123\trefs/tags/dev/app/feature-auth/notanumber",
+            "bad-line-without-tab",
+            "abc123\trefs/tags/release/app/v1.0.0",
+        ) { tagRef ->
+            DevTagPattern.parseDevTagNumber(tagRef, "app", "feature-auth").shouldBeNull()
+        }
+    }
+
+    context("validateBranchName accepts valid names") {
+        withData(
+            "feature-auth",
+            "my.feature",
+            "JIRA-1234",
+            "v2-migration",
+            "a",
+            "A123_test.name-ok",
+        ) { name ->
+            // should not throw
+            DevTagPattern.validateBranchName(name)
+        }
+    }
+
+    context("validateBranchName throws for invalid names") {
+        withData(
+            "" to "blank",
+            "   " to "blank",
+            "has space" to "Invalid",
+            "has/slash" to "Invalid",
+            ".leading-dot" to "Invalid",
+            "-leading-dash" to "Invalid",
+            "_leading-underscore" to "Invalid",
+            "has~tilde" to "Invalid",
+            "has^caret" to "Invalid",
+            "has:colon" to "Invalid",
+            "has?question" to "Invalid",
+            "has*star" to "Invalid",
+            "has[bracket" to "Invalid",
+        ) { (name, expectedInMessage) ->
+            val exception = shouldThrow<GradleException> {
+                DevTagPattern.validateBranchName(name)
+            }
+            exception.message shouldContain expectedInMessage
+        }
+    }
+
+    test("parseDevBranch round-trips with formatDevBranch") {
+        // given
+        val projectPrefix = "services/auth"
+        val branchName = "feature-x"
+        val branch = DevTagPattern.formatDevBranch(projectPrefix, branchName)
+
+        // when
+        val parsed = DevTagPattern.parseDevBranch(branch)
+
+        // then
+        parsed shouldBe DevBranchInfo(projectPrefix, branchName)
+    }
+})

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/DevTagPatternTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/domain/DevTagPatternTest.kt
@@ -118,6 +118,8 @@ class DevTagPatternTest : FunSpec({
             "v2-migration",
             "a",
             "A123_test.name-ok",
+            "123-feature",
+            "0day-fix",
         ) { name ->
             // should not throw
             DevTagPattern.validateBranchName(name)

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/release/git/DevTagScannerTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/release/git/DevTagScannerTest.kt
@@ -1,0 +1,134 @@
+package io.github.doughawley.monorepo.release.git
+
+import io.github.doughawley.monorepo.git.GitCommandExecutor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+
+class DevTagScannerTest : FunSpec({
+
+    val executor = mockk<GitCommandExecutor>()
+    val rootDir = File("/fake/root")
+    val scanner = DevTagScanner(rootDir, executor)
+
+    afterEach { clearAllMocks() }
+
+    // findLatestDevTagNumber
+
+    test("findLatestDevTagNumber returns null when remote has no matching tags") {
+        // given
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--tags", "--refs", "origin", "refs/tags/dev/app/feature-auth/*")
+        } returns emptyList()
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result.shouldBeNull()
+    }
+
+    test("findLatestDevTagNumber returns the maximum number from ls-remote output") {
+        // given
+        val lines = listOf(
+            "abc123\trefs/tags/dev/app/feature-auth/1",
+            "def456\trefs/tags/dev/app/feature-auth/3",
+            "ghi789\trefs/tags/dev/app/feature-auth/2",
+        )
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--tags", "--refs", "origin", "refs/tags/dev/app/feature-auth/*")
+        } returns lines
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result shouldBe 3
+    }
+
+    test("findLatestDevTagNumber ignores malformed tag lines") {
+        // given
+        val lines = listOf(
+            "abc123\trefs/tags/dev/app/feature-auth/1",
+            "bad-line-with-no-tab",
+            "abc123\trefs/tags/dev/app/feature-auth/notanumber",
+        )
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--tags", "--refs", "origin", "refs/tags/dev/app/feature-auth/*")
+        } returns lines
+
+        // when
+        val result = scanner.findLatestDevTagNumber("app", "feature-auth")
+
+        // then
+        result shouldBe 1
+    }
+
+    test("findLatestDevTagNumber uses projectPrefix and branchName in the ref pattern") {
+        // given
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--tags", "--refs", "origin", "refs/tags/dev/services/auth/experiment/*")
+        } returns listOf("abc123\trefs/tags/dev/services/auth/experiment/5")
+
+        // when
+        val result = scanner.findLatestDevTagNumber("services/auth", "experiment")
+
+        // then
+        result shouldBe 5
+    }
+
+    test("findLatestDevTagNumber throws when git ls-remote fails") {
+        // given
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--tags", "--refs", "origin", "refs/tags/dev/app/feature-auth/*")
+        } throws RuntimeException("Git command failed (exit code 128): fatal: could not read from remote repository")
+
+        // when / then
+        val ex = shouldThrow<RuntimeException> { scanner.findLatestDevTagNumber("app", "feature-auth") }
+        ex.message shouldContain "Git command failed"
+    }
+
+    // devBranchExistsOnRemote
+
+    test("devBranchExistsOnRemote returns true when remote has the branch") {
+        // given
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--heads", "origin", "refs/heads/dev/app/feature-auth")
+        } returns listOf("abc123\trefs/heads/dev/app/feature-auth")
+
+        // when
+        val result = scanner.devBranchExistsOnRemote("app", "feature-auth")
+
+        // then
+        result shouldBe true
+    }
+
+    test("devBranchExistsOnRemote returns false when remote does not have the branch") {
+        // given
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--heads", "origin", "refs/heads/dev/app/feature-auth")
+        } returns emptyList()
+
+        // when
+        val result = scanner.devBranchExistsOnRemote("app", "feature-auth")
+
+        // then
+        result shouldBe false
+    }
+
+    test("devBranchExistsOnRemote throws when git ls-remote fails") {
+        // given
+        every {
+            executor.executeForOutput(rootDir, "ls-remote", "--heads", "origin", "refs/heads/dev/app/feature-auth")
+        } throws RuntimeException("Git command failed (exit code 128): fatal: could not read from remote repository")
+
+        // when / then
+        shouldThrow<RuntimeException> { scanner.devBranchExistsOnRemote("app", "feature-auth") }
+    }
+})


### PR DESCRIPTION
## Summary

- Add `createDevBranch` and `devRelease` per-project tasks for building and releasing experimental features from non-main branches
- Dev releases are completely decoupled from stable versioning — use simple incrementing tags (`dev/<project>/<name>/1`, `/2`, `/3`)
- Branch format: `dev/<project-prefix>/<name>`, version written to `release-version.txt`: `<name>.<N>`

## New tasks

| Task | Description |
|------|-------------|
| `:app:createDevBranch -Pdev.branch.name=feature-auth` | Creates and pushes `dev/app/feature-auth` branch |
| `:app:devRelease` | Builds the app, creates an incrementing dev tag, writes version file |

## New files

| File | Role |
|------|------|
| `DevTagPattern.kt` | Formatting, parsing, and validation for dev branch/tag conventions |
| `DevTagScanner.kt` | Remote tag/branch scanning for dev releases |
| `CreateDevBranchTask.kt` | Creates dev branches with validation and rollback |
| `DevReleaseTask.kt` | Creates dev release tags with auto-increment |

## Test plan

- [x] Unit tests: `DevTagPatternTest`, `DevTagScannerTest`
- [x] Integration tests: `DevTagScannerIntegrationTest` (real git repos)
- [x] Functional tests: `CreateDevBranchFunctionalTest`, `DevReleaseFunctionalTest` (Gradle TestKit)
- [x] Full `./gradlew check` passes

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)