### PR TITLE
fix: guard against dependency cycles in ProjectMetadataFactory recursion

### DIFF
--- a/src/main/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataFactory.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataFactory.kt
@@ -31,7 +31,7 @@ class ProjectMetadataFactory(private val logger: Logger) {
 
         // Build metadata recursively for each project
         projectMap.forEach { (_, project) ->
-            buildMetadataRecursively(project, projectMap, metadataMap, changedFilesMap)
+            buildMetadataRecursively(project, projectMap, metadataMap, changedFilesMap, mutableSetOf())
         }
 
         return metadataMap
@@ -39,25 +39,44 @@ class ProjectMetadataFactory(private val logger: Logger) {
 
     /**
      * Recursively builds ProjectMetadata for a project and its dependencies.
+     *
+     * The [inProgress] set holds the recursion stack so that self-references
+     * (e.g. the one java-test-fixtures adds via testImplementation(testFixtures(project)))
+     * and cross-configuration dependency cycles cannot recurse forever (issue #204).
      */
     private fun buildMetadataRecursively(
         project: Project,
         projectMap: Map<String, Project>,
         metadataMap: MutableMap<String, ProjectMetadata>,
-        changedFilesMap: Map<String, List<String>>
+        changedFilesMap: Map<String, List<String>>,
+        inProgress: MutableSet<String>
     ): ProjectMetadata {
         // Return cached metadata if already built
         metadataMap[project.path]?.let {
             return it
         }
 
+        inProgress.add(project.path)
+
         // Find dependency paths
         val dependencyPaths = findProjectDependencies(project)
 
         // Recursively build metadata for each dependency (nested objects)
         val dependencyMetadataList = dependencyPaths.mapNotNull { depPath ->
-            projectMap[depPath]?.let { depProject ->
-                buildMetadataRecursively(depProject, projectMap, metadataMap, changedFilesMap)
+            if (depPath == project.path) {
+                logger.debug("Skipping self-referencing dependency of ${project.path}")
+                null
+            } else if (depPath in inProgress) {
+                logger.warn(
+                    "Dependency cycle detected between ${project.path} and $depPath; " +
+                        "ignoring the ${project.path} -> $depPath edge for change detection. " +
+                        "Projects in a dependency cycle may not be detected as affected by each other's changes."
+                )
+                null
+            } else {
+                projectMap[depPath]?.let { depProject ->
+                    buildMetadataRecursively(depProject, projectMap, metadataMap, changedFilesMap, inProgress)
+                }
             }
         }
 
@@ -74,6 +93,7 @@ class ProjectMetadataFactory(private val logger: Logger) {
 
         // Cache the metadata
         metadataMap[project.path] = metadata
+        inProgress.remove(project.path)
 
         return metadata
     }

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
@@ -75,6 +75,59 @@ class MonorepoPluginConfigurationTest : FunSpec({
         result.output shouldContain "org.gradle.configuration-cache=false"
     }
 
+    test("plugin handles self-referencing dependency from java-test-fixtures") {
+        // given: :lib applies java-test-fixtures, which adds a ProjectDependency on :lib itself;
+        // :app depends on :lib (issue #204 — StackOverflowError in ProjectMetadataFactory)
+        val projectDir = testProjectListener.getTestProjectDir()
+        val project = TestProjectBuilder(projectDir)
+            .withSubproject("lib", extraPlugins = listOf("java-test-fixtures"))
+            .withSubproject("app", dependsOn = listOf("lib"))
+            .applyPlugin()
+            .withRemote()
+            .build()
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+
+        // when: a file in :lib changes
+        project.appendToFile("lib/src/main/kotlin/com/example/Lib.kt", "// Modified lib")
+        project.commitAll("Change lib")
+        val result = project.runTask("printChanged")
+
+        // then: no StackOverflowError; :lib and its dependent :app are detected
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        val changedProjects = result.extractChangedProjects()
+        changedProjects shouldContain ":lib"
+        changedProjects shouldContain ":app"
+    }
+
+    test("plugin handles cross-configuration dependency cycle between projects") {
+        // given: :cycle-a testImplementation-depends on :cycle-b while :cycle-b
+        // implementation-depends on :cycle-a — legal in Gradle, but a declared cycle
+        // (issue #204 — StackOverflowError in ProjectMetadataFactory)
+        val projectDir = testProjectListener.getTestProjectDir()
+        val project = TestProjectBuilder(projectDir)
+            .withSubproject("cycle-a", testDependsOn = listOf("cycle-b"))
+            .withSubproject("cycle-b", dependsOn = listOf("cycle-a"))
+            .applyPlugin()
+            .withRemote()
+            .build()
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+
+        // when: a file in :cycle-a changes
+        project.appendToFile("cycle-a/src/main/kotlin/com/example/CycleA.kt", "// Modified cycle-a")
+        project.commitAll("Change cycle-a")
+        val result = project.runTask("printChanged")
+
+        // then: no StackOverflowError; the directly changed project is detected
+        // and the user is warned about the cycle
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.extractChangedProjects() shouldContain ":cycle-a"
+        result.output shouldContain "Dependency cycle detected"
+    }
+
     test("plugin fails with helpful error when not inside a git repository") {
         // given: a project with the plugin applied but no git init
         val projectDir = testProjectListener.getTestProjectDir()

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/TestProjectBuilder.kt
@@ -18,7 +18,9 @@ class TestProjectBuilder(private val projectDir: File) {
         val dependencies: List<String> = emptyList(),
         val isBom: Boolean = false,
         val usePlatform: Boolean = false,
-        val excludePatterns: List<String> = emptyList()
+        val excludePatterns: List<String> = emptyList(),
+        val extraPlugins: List<String> = emptyList(),
+        val testDependsOn: List<String> = emptyList()
     )
 
     fun withSubproject(
@@ -26,9 +28,11 @@ class TestProjectBuilder(private val projectDir: File) {
         dependsOn: List<String> = emptyList(),
         isBom: Boolean = false,
         usePlatform: Boolean = false,
-        excludePatterns: List<String> = emptyList()
+        excludePatterns: List<String> = emptyList(),
+        extraPlugins: List<String> = emptyList(),
+        testDependsOn: List<String> = emptyList()
     ): TestProjectBuilder {
-        subprojects.add(SubprojectConfig(name, dependsOn, isBom, usePlatform, excludePatterns))
+        subprojects.add(SubprojectConfig(name, dependsOn, isBom, usePlatform, excludePatterns, extraPlugins, testDependsOn))
         return this
     }
 
@@ -103,9 +107,12 @@ class TestProjectBuilder(private val projectDir: File) {
                 } else {
                     appendLine("    java")
                 }
+                subproject.extraPlugins.forEach { pluginId ->
+                    appendLine("    id(\"$pluginId\")")
+                }
                 appendLine("}")
                 appendLine()
-                if (subproject.dependencies.isNotEmpty()) {
+                if (subproject.dependencies.isNotEmpty() || subproject.testDependsOn.isNotEmpty()) {
                     appendLine("dependencies {")
 
                     // Separate platform dependencies from regular dependencies
@@ -126,6 +133,11 @@ class TestProjectBuilder(private val projectDir: File) {
                             val gradlePath = dep.replace("/", ":")
                             appendLine("    implementation(project(\":$gradlePath\"))")
                         }
+                    }
+
+                    subproject.testDependsOn.forEach { dep ->
+                        val gradlePath = dep.replace("/", ":")
+                        appendLine("    testImplementation(project(\":$gradlePath\"))")
                     }
 
                     appendLine("}")

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataFactoryTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/domain/ProjectMetadataFactoryTest.kt
@@ -500,6 +500,105 @@ class ProjectMetadataFactoryTest : FunSpec({
         serviceMetadata.dependencies[0].fullyQualifiedName shouldBe ":platform"
     }
 
+    test("should not recurse infinitely on self-referencing dependency") {
+        // given: a project that declares a dependency on itself, as java-test-fixtures does
+        // via testImplementation(testFixtures(project)) (issue #204)
+        val rootProject = ProjectBuilder.builder().build()
+        val lib = ProjectBuilder.builder()
+            .withParent(rootProject)
+            .withName("lib")
+            .build()
+
+        lib.pluginManager.apply("java-library")
+        lib.dependencies.add("testImplementation", lib)
+
+        val logger = rootProject.logger
+        val factory = ProjectMetadataFactory(logger)
+
+        // when
+        val metadataMap = factory.buildProjectMetadataMap(rootProject)
+
+        // then: the self-reference is dropped instead of overflowing the stack
+        val libMetadata = metadataMap[":lib"]
+        libMetadata shouldNotBe null
+        libMetadata!!.dependencies shouldHaveSize 0
+    }
+
+    test("should not recurse infinitely when java-test-fixtures plugin is applied") {
+        // given: java-test-fixtures automatically adds a ProjectDependency on the project itself
+        val rootProject = ProjectBuilder.builder().build()
+        val lib = ProjectBuilder.builder()
+            .withParent(rootProject)
+            .withName("lib")
+            .build()
+        val app = ProjectBuilder.builder()
+            .withParent(rootProject)
+            .withName("app")
+            .build()
+
+        lib.pluginManager.apply("java-library")
+        lib.pluginManager.apply("java-test-fixtures")
+        app.pluginManager.apply("java-library")
+        app.dependencies.add("implementation", lib)
+
+        val logger = rootProject.logger
+        val factory = ProjectMetadataFactory(logger)
+
+        // when
+        val metadataMap = factory.buildProjectMetadataMap(rootProject)
+
+        // then: real dependencies are preserved, the self-reference is dropped
+        val libMetadata = metadataMap[":lib"]
+        libMetadata shouldNotBe null
+        libMetadata!!.dependencies shouldHaveSize 0
+
+        val appMetadata = metadataMap[":app"]
+        appMetadata shouldNotBe null
+        appMetadata!!.dependencies shouldHaveSize 1
+        appMetadata.dependencies[0].fullyQualifiedName shouldBe ":lib"
+    }
+
+    test("should not recurse infinitely on cross-configuration dependency cycle") {
+        // given: :lib-a testImplementation-depends on :lib-b while :lib-b
+        // implementation-depends on :lib-a — legal in Gradle, but a declared cycle (issue #204)
+        val rootProject = ProjectBuilder.builder().build()
+        val libA = ProjectBuilder.builder()
+            .withParent(rootProject)
+            .withName("lib-a")
+            .build()
+        val libB = ProjectBuilder.builder()
+            .withParent(rootProject)
+            .withName("lib-b")
+            .build()
+
+        libA.pluginManager.apply("java-library")
+        libB.pluginManager.apply("java-library")
+        libA.dependencies.add("testImplementation", libB)
+        libB.dependencies.add("implementation", libA)
+
+        val logger = rootProject.logger
+        val factory = ProjectMetadataFactory(logger)
+
+        val changedFilesMap = mapOf(
+            ":lib-b" to listOf("lib-b/File.kt")
+        )
+
+        // when
+        val metadataMap = factory.buildProjectMetadataMap(rootProject, changedFilesMap)
+
+        // then: metadata is built for both projects without overflowing the stack,
+        // and change detection still propagates along the retained edge
+        val libAMetadata = metadataMap[":lib-a"]
+        libAMetadata shouldNotBe null
+        libAMetadata!!.dependencies shouldHaveSize 1
+        libAMetadata.dependencies[0].fullyQualifiedName shouldBe ":lib-b"
+        libAMetadata.hasChanges() shouldBe true
+
+        val libBMetadata = metadataMap[":lib-b"]
+        libBMetadata shouldNotBe null
+        libBMetadata!!.hasChanges() shouldBe true
+    }
+
     test("should handle projects with no changes in changed files map") {
         // given
         val rootProject = ProjectBuilder.builder().build()


### PR DESCRIPTION
Fixes #204

## Problem

`ProjectMetadataFactory.buildMetadataRecursively` cached a project's metadata only *after* recursing into all of its dependencies, so any declared dependency cycle recursed forever and crashed every Gradle invocation with `StackOverflowError` in `projectsEvaluated`. Both trigger shapes from the issue reproduce:

- **Self-reference:** the `java-test-fixtures` plugin automatically adds `testImplementation(testFixtures(project))`, a `ProjectDependency` on the project itself.
- **Cross-configuration cycle:** `:a` declares `testImplementation(project(":b"))` while `:b` declares `implementation(project(":a"))` — legal in Gradle, but a declared cycle since dependencies are unioned across all configurations.

## Fix

The recursion now carries an `inProgress` set holding the recursion stack:

- **Self-references** are dropped with a debug log — they are meaningless for change detection, so this is exactly correct for `java-test-fixtures`.
- **Back edges of genuine cross-project cycles** are dropped with a warning. The immutable nested `ProjectMetadata` model cannot represent a true cycle, so the warning tells users that affected-project detection may be incomplete for cycle members.

## Testing

- Added 2 functional tests (`MonorepoPluginConfigurationTest.kt`) spinning up real TestKit projects for each cycle shape, plus 3 unit tests (`ProjectMetadataFactoryTest.kt`). All 5 failed with `StackOverflowError` before the fix and pass after.
- `TestProjectBuilder` gained support for extra plugins and `testImplementation` project dependencies to build the reproductions.
- Full `./gradlew check` (unit + integration + functional + plugin validation) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)