### PR TITLE
fix: treat root-level shared build files as affecting all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ monorepo {
             ".*\\.md",
             "docs/.*"
         )
+        rootTriggerPatterns = listOf(   // regex patterns for root-level files that affect all projects; defaults shown below
+            "build\\.gradle(\\.kts)?",
+            "settings\\.gradle(\\.kts)?",
+            "gradle\\.properties",
+            "gradle/.*\\.versions\\.toml",
+            "buildSrc/.*",
+            "gradle/wrapper/.*"
+        )
+    }
+}
+```
+
+#### Root-level trigger files (`rootTriggerPatterns`)
+
+Changed files that are not inside any subproject directory are attributed to the root project. When such a file matches one of the `rootTriggerPatterns`, **all projects are treated as affected**, because these files can change how every subproject builds. Other root-level files (e.g. a root `README.md`) do not affect any project.
+
+How matching works:
+
+- Patterns are regular expressions matched against the **full file path relative to the repository root**, using forward slashes (e.g. `gradle/libs.versions.toml`).
+- Only files **outside every subproject directory** are checked — a subproject's own `build.gradle.kts` still affects just that project and its dependents.
+- The defaults cover the root build script, settings script, `gradle.properties`, version catalogs (`gradle/*.versions.toml`), `buildSrc` sources, and the Gradle wrapper.
+- Assigning a new list **replaces** the defaults. To extend them instead, append to the current value:
+
+```kotlin
+monorepo {
+    build {
+        rootTriggerPatterns = rootTriggerPatterns + listOf("config/.*")
     }
 }
 ```
@@ -396,6 +423,7 @@ jobs:
 | `lastSuccessfulBuildTag` | String | `"monorepo/last-successful-build"` | Tag name used as the anchor for change detection; updated automatically after successful builds |
 | `includeUntracked` | Boolean | `true` | Whether to include untracked, staged, and working-tree files in detection |
 | `excludePatterns` | List\<String\> | `[]` | Regex patterns for files to exclude globally across all projects |
+| `rootTriggerPatterns` | List\<String\> | root build/settings scripts, `gradle.properties`, `gradle/*.versions.toml`, `buildSrc/**`, `gradle/wrapper/**` | Regex patterns for root-level files (outside any subproject) that affect the build of every project; a match marks all projects as affected |
 
 ### `monorepoProject { build { } }`
 
@@ -460,6 +488,10 @@ Check your `excludePatterns` configuration - you may be inadvertently excluding 
 ### Root project always shows as changed
 
 This is expected if files in the root directory (outside of subproject directories) have changed. To prevent this, ensure all code is within subproject directories.
+
+### All projects marked as affected after a root-level change
+
+When a root-level file matching `rootTriggerPatterns` changes (root build script, version catalog, `buildSrc`, etc.), all projects are treated as affected because those files can change how every subproject builds. If a root-level file is being over-matched, adjust `rootTriggerPatterns` in `monorepo { build { } }`.
 
 ## Support & Contributions
 

--- a/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/MonorepoBuildReleasePlugin.kt
@@ -425,19 +425,60 @@ class MonorepoBuildReleasePlugin : Plugin<Project> {
         val monorepoProjects = MonorepoProjects(metadataMap.values.toList())
         extension.monorepoProjects = monorepoProjects
 
-        val allAffectedProjects = monorepoProjects.getChangedProjectPaths()
+        val allAffectedProjects = computeAffectedProjects(
+            project.rootProject,
+            extension,
+            filteredChangedFilesMap,
+            monorepoProjects,
+            logger
+        )
+        extension.allAffectedProjects = allAffectedProjects
+
+        logger.info("Changed files count: ${changedFiles.size}")
+        logger.info("All affected projects (including dependents): ${allAffectedProjects.joinToString(", ").ifEmpty { "none" }}")
+    }
+
+    /**
+     * Computes the set of affected project paths.
+     *
+     * Changed files attributed to the root project (not inside any subproject directory)
+     * that match [MonorepoBuildExtension.rootTriggerPatterns] — the root build script,
+     * version catalogs, buildSrc, etc. — affect how every subproject builds, so all
+     * projects with build files are treated as affected. Otherwise the affected set is
+     * the changed projects (including transitive dependents), excluding the root project
+     * and projects without build files.
+     */
+    private fun computeAffectedProjects(
+        rootProject: Project,
+        extension: MonorepoBuildExtension,
+        changedFilesMap: Map<String, List<String>>,
+        monorepoProjects: MonorepoProjects,
+        logger: Logger
+    ): Set<String> {
+        val triggerPatterns = extension.rootTriggerPatterns.map { Regex(it) }
+        val rootTriggerFiles = (changedFilesMap[rootProject.path] ?: emptyList())
+            .filter { file -> triggerPatterns.any { pattern -> file.matches(pattern) } }
+
+        if (rootTriggerFiles.isNotEmpty()) {
+            logger.lifecycle(
+                "Root-level build files changed (${rootTriggerFiles.joinToString(", ")}) — " +
+                "treating all projects as affected"
+            )
+            return rootProject.subprojects
+                .map { it.path }
+                .filter { path -> hasBuildFile(rootProject, path) }
+                .toSet()
+        }
+
+        return monorepoProjects.getChangedProjectPaths()
             .filter { path ->
-                path != ":" && hasBuildFile(project.rootProject, path).also { hasBuild ->
+                path != ":" && hasBuildFile(rootProject, path).also { hasBuild ->
                     if (!hasBuild) {
                         logger.debug("Excluding $path from affected projects: no build file found")
                     }
                 }
             }
             .toSet()
-        extension.allAffectedProjects = allAffectedProjects
-
-        logger.info("Changed files count: ${changedFiles.size}")
-        logger.info("All affected projects (including dependents): ${allAffectedProjects.joinToString(", ").ifEmpty { "none" }}")
     }
 
     /**

--- a/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
+++ b/src/main/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildExtension.kt
@@ -33,6 +33,26 @@ open class MonorepoBuildExtension {
     var excludePatterns: List<String> = listOf()
 
     /**
+     * Regex patterns for root-level files that affect the build of every project.
+     *
+     * Changed files that are not inside any subproject directory are attributed to the
+     * root project. When such a file matches one of these patterns, all projects are
+     * treated as affected, because files like the root build script, the version catalog,
+     * or buildSrc sources can change how every subproject builds.
+     *
+     * Patterns are matched against the full file path relative to the root project
+     * (forward slashes). Assigning a new list replaces the defaults.
+     */
+    var rootTriggerPatterns: List<String> = listOf(
+        "build\\.gradle(\\.kts)?",
+        "settings\\.gradle(\\.kts)?",
+        "gradle\\.properties",
+        "gradle/.*\\.versions\\.toml",
+        "buildSrc/.*",
+        "gradle/wrapper/.*"
+    )
+
+    /**
      * The ref that was actually used for change detection, or null when no baseline exists
      * (all projects treated as changed). Set internally after ref resolution.
      *

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/BuildChangedFunctionalTest.kt
@@ -520,6 +520,67 @@ class BuildChangedFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
+    // Root-level shared build files (issue #205)
+    // ─────────────────────────────────────────────────────────────
+
+    test("buildChanged builds all projects when the version catalog changes") {
+        // given
+        val project = testProjectListener.createStandardProject()
+        project.createNewFile("gradle/libs.versions.toml", "[versions]\nsome-lib = \"2.0.0\"")
+        project.commitAll("Bump dependency version in catalog")
+
+        // when
+        val result = project.runTask("buildChanged")
+
+        // then: the catalog affects every project's build
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.extractBuiltProjects() shouldContainAll setOf(
+            Projects.PLATFORM,
+            Projects.COMMON_LIB,
+            Projects.MODULE1,
+            Projects.MODULE2,
+            Projects.APP1,
+            Projects.APP2
+        )
+    }
+
+    test("buildChanged builds all projects when the root build script changes") {
+        // given
+        val project = testProjectListener.createStandardProject()
+        project.appendToFile("build.gradle.kts", "\n// allprojects configuration change")
+        project.commitAll("Change root build script")
+
+        // when
+        val result = project.runTask("buildChanged")
+
+        // then
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.extractBuiltProjects() shouldContainAll setOf(
+            Projects.PLATFORM,
+            Projects.COMMON_LIB,
+            Projects.MODULE1,
+            Projects.MODULE2,
+            Projects.APP1,
+            Projects.APP2
+        )
+    }
+
+    test("buildChanged builds nothing when a non-build root file changes") {
+        // given
+        val project = testProjectListener.createStandardProject()
+        project.createNewFile("README.md", "# Documentation only")
+        project.commitAll("Add readme")
+
+        // when
+        val result = project.runTask("buildChanged")
+
+        // then: a docs-only root change does not affect any project
+        result.task(":buildChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain "No projects have changed - nothing to build"
+        result.extractExecutedBuildTasks().shouldBeEmpty()
+    }
+
+    // ─────────────────────────────────────────────────────────────
     // Git command failure propagation
     // ─────────────────────────────────────────────────────────────
 

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/build/functional/MonorepoPluginConfigurationTest.kt
@@ -63,6 +63,51 @@ class MonorepoPluginConfigurationTest : FunSpec({
         changedProjects shouldContain ":core"
     }
 
+    test("custom rootTriggerPatterns treat matching root files as affecting all projects") {
+        // given: rootTriggerPatterns replaced so only ci/** files affect all projects
+        val projectDir = testProjectListener.getTestProjectDir()
+        val project = TestProjectBuilder(projectDir)
+            .withSubproject("api")
+            .withSubproject("core")
+            .applyPlugin()
+            .withRemote()
+            .build()
+        project.modifyFile(
+            "build.gradle.kts",
+            """
+            plugins {
+                id("io.github.doug-hawley.monorepo-build-release-plugin")
+            }
+
+            monorepo {
+                build {
+                    includeUntracked = true
+                    rootTriggerPatterns = listOf("ci/.*")
+                }
+            }
+
+            allprojects {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            """.trimIndent()
+        )
+        project.initGit()
+        project.commitAll("Initial commit")
+        project.pushToRemote()
+
+        // when: a file matching the custom pattern is created (untracked)
+        project.createNewFile("ci/pipeline.yml", "steps: []")
+        val result = project.runTask("printChanged")
+
+        // then: all projects are affected even though no project file changed
+        result.task(":printChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        val affectedProjects = result.extractBuiltProjects()
+        affectedProjects shouldContain ":api"
+        affectedProjects shouldContain ":core"
+    }
+
     test("plugin fails with helpful error when configuration cache is requested") {
         // given: a standard project with the plugin applied
         val project = testProjectListener.createStandardProject()

--- a/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseChangedFunctionalTest.kt
+++ b/src/test/functional/kotlin/io/github/doughawley/monorepo/release/functional/ReleaseChangedFunctionalTest.kt
@@ -124,6 +124,32 @@ class ReleaseChangedFunctionalTest : FunSpec({
     }
 
     // ─────────────────────────────────────────────────────────────
+    // Root-level shared build files (issue #205)
+    // ─────────────────────────────────────────────────────────────
+
+    test("creates release branches for all opted-in projects when the version catalog changes") {
+        // given: a dependency bump in the version catalog merged after the last successful build
+        val project = StandardReleaseTestProject.createMultiProjectAndInitialize(testListener.getTestProjectDir())
+        project.createTag("monorepo/last-successful-build")
+        project.pushTag("monorepo/last-successful-build")
+        project.modifyFile("gradle/libs.versions.toml", "[versions]\nsome-lib = \"2.0.0\"")
+        project.commitAll("Bump dependency version in catalog")
+        val headCommit = project.headCommit()
+
+        // when
+        val result = project.runTask("releaseChanged")
+
+        // then: the catalog change is built and released, not silently dropped
+        result.task(":releaseChanged")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldNotContain "No projects have changed"
+        result.task(":app:build")?.outcome shouldBe TaskOutcome.SUCCESS
+        result.task(":lib:build")?.outcome shouldBe TaskOutcome.SUCCESS
+        project.remoteBranches() shouldContain "release/app/v0.1.x"
+        project.remoteBranches() shouldContain "release/lib/v0.1.x"
+        project.remoteTagCommit("monorepo/last-successful-build") shouldBe headCommit
+    }
+
+    // ─────────────────────────────────────────────────────────────
     // Tag-based baseline (not origin/main)
     // ─────────────────────────────────────────────────────────────
 

--- a/src/test/unit/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildPluginTest.kt
+++ b/src/test/unit/kotlin/io/github/doughawley/monorepo/build/MonorepoBuildPluginTest.kt
@@ -50,6 +50,14 @@ class MonorepoBuildPluginTest : FunSpec({
         buildExtension.lastSuccessfulBuildTag shouldBe "monorepo/last-successful-build"
         buildExtension.includeUntracked shouldBe true
         buildExtension.excludePatterns shouldBe emptyList()
+        buildExtension.rootTriggerPatterns shouldBe listOf(
+            "build\\.gradle(\\.kts)?",
+            "settings\\.gradle(\\.kts)?",
+            "gradle\\.properties",
+            "gradle/.*\\.versions\\.toml",
+            "buildSrc/.*",
+            "gradle/wrapper/.*"
+        )
     }
 
     test("extension can be configured") {


### PR DESCRIPTION
Fixes #205

## Problem

Files not inside any subproject directory are attributed to the root project (`:`), which `computeMetadata` unconditionally drops from `allAffectedProjects`. Since no subproject depends on the root, changes to root-level shared build files — the root `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`, `gradle/libs.versions.toml`, `buildSrc/**`, `gradle/wrapper/**` — never triggered any build. Worse, `releaseChanged` logged "No projects have changed — nothing to do" and **still force-updated the `monorepo/last-successful-build` tag to HEAD**, permanently advancing the baseline past the change. A version-catalog dependency bump was silently never built and never released.

## Fix

- New `rootTriggerPatterns` config on `monorepo { build { } }`: a regex list matched against root-attributed changed file paths, defaulting to the list above. When any changed file matches, every subproject with a build file is treated as affected (with a lifecycle log explaining why).
- Non-matching root-level files (e.g. a root `README.md`) still affect nothing, so docs-only merges continue to skip builds.
- Assignment replaces the defaults, matching `excludePatterns` semantics; README documents matching rules and the `rootTriggerPatterns + listOf(...)` extend idiom.

## Tests

Written first and verified to fail against the old behavior:

- `buildChanged` builds all projects on a version-catalog change and on a root build-script change (`BuildChangedFunctionalTest`)
- `buildChanged` still builds nothing for a non-build root file (guard against over-triggering)
- `releaseChanged` builds and releases all opted-in projects on a catalog change instead of silently dropping it, and only then advances the baseline tag (`ReleaseChangedFunctionalTest`)
- Custom `rootTriggerPatterns` configuration end-to-end (`MonorepoPluginConfigurationTest`)
- Extension defaults (`MonorepoBuildPluginTest`)

Full `./gradlew check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)